### PR TITLE
Use module names for YAML tag prefixes

### DIFF
--- a/README-pypi.rst
+++ b/README-pypi.rst
@@ -97,7 +97,7 @@ Define an ``Experiment``:
 
     # Define how to schedule variants
     schedulers:
-      train: !tune.HyperBandScheduler
+      train: !ray.HyperBandScheduler
 
 All objects in the ``pipeline`` are subclasses of ``Component``, which
 are automatically registered to be used with YAML. Custom ``Component``

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Define an ``Experiment``:
 
     # Define how to schedule variants
     schedulers:
-      train: !tune.HyperBandScheduler
+      train: !ray.HyperBandScheduler
 
 All objects in the ``pipeline`` are subclasses of ``Component``, which
 are automatically registered to be used with YAML. Custom ``Component``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,7 +68,7 @@ Visit the github repo: https://github.com/Open-ASAPP/flambe
 
     # Define how to schedule variants
     schedulers:
-      train: !tune.HyperBandScheduler
+      train: !ray.HyperBandScheduler
 
 
 The experiment can be executed by running:

--- a/docs/starting/usage.rst
+++ b/docs/starting/usage.rst
@@ -154,7 +154,7 @@ a powerful and flexible implementation called :class:`~flambe.learn.Trainer`:
 
 .. tip::
   Additionally we setup some ``Tune`` classes for use with hyperparameter search and scheduling.
-  They can be accessed via ``!tune.ClassName`` tags. More on hyperparameter search and
+  They can be accessed via ``!ray.ClassName`` tags. More on hyperparameter search and
   scheduling in :ref:`understanding-experiments_label`.
 
 

--- a/docs/understanding/experiments.rst
+++ b/docs/understanding/experiments.rst
@@ -276,7 +276,7 @@ HyperBand, and soon more complex search algorithms like HyperOpt will be availab
 .. code-block:: yaml
 
     schedulers:
-        b1: !tune.HyperBandScheduler
+        b1: !ray.HyperBandScheduler
 
     pipeline:
         b0: !ext.TCProcessor

--- a/examples/basic_example.yaml
+++ b/examples/basic_example.yaml
@@ -37,8 +37,8 @@ pipeline:
     metric_fn: !Accuracy
     optimizer: !torch.Adam
       params: !@ train.model.trainable_params
-    max_steps: 100
-    iter_per_step: 100
+    max_steps: 2
+    iter_per_step: 2
 
   # Stage 3 - Eval on the test set
   eval: !Evaluator
@@ -49,4 +49,4 @@ pipeline:
 
 # Define how to schedule variants
 schedulers:
-  train: !tune.HyperBandScheduler
+  train: !ray.HyperBandScheduler

--- a/examples/full_example.yaml
+++ b/examples/full_example.yaml
@@ -47,6 +47,6 @@ pipeline: # Define the list of components to execute
     text: !@ 2_evaluate.dataset.text
 
 schedulers: # Define how to schedule variants
-  1_train: !tune.HyperBandScheduler
+  1_train: !ray.HyperBandScheduler
 reduce: # Only use the best variant in subsequent blocks, meaning only the best Trainer will be linked to the Evaluator stage
   1_train: 1

--- a/flambe/compile/component.py
+++ b/flambe/compile/component.py
@@ -1329,24 +1329,22 @@ def dynamic_component(class_: Type[A],
     if issubclass(class_, Component):
         return class_
 
+    # Copy over class attributes so it still looks like the original
+    # Useful for inspection and debugging purposes
+    _MISSING = object()
+    copied_attrs = {}
+    for k in WRAPPER_ASSIGNMENTS:
+        v = getattr(class_, k, _MISSING)
+        if v is not _MISSING:
+            copied_attrs[k] = v
+
     # Create new subclass of `class_` and `Component`
     # Ignore mypy, extra kwargs are okay in python 3.6+ usage of type
     # and Registrable uses them
     new_component = type(class_.__name__,  # type: ignore
                          (Component, class_),
-                         {},
+                         copied_attrs,
                          tag_override=tag,
                          tag_namespace=tag_namespace)  # type: ignore
-
-    # Copy over class attributes so it still looks like the original
-    # Useful for inspection and debugging purposes
-    _MISSING = object()
-    for k in WRAPPER_ASSIGNMENTS:
-        v = getattr(class_, k, _MISSING)
-        if v is not _MISSING:
-            try:
-                setattr(new_component, k, v)
-            except AttributeError:
-                pass
 
     return new_component

--- a/flambe/compile/extensions.py
+++ b/flambe/compile/extensions.py
@@ -263,41 +263,38 @@ def import_modules(modules: Iterable[str]) -> None:
 
     """
     for mod_name in modules:
-        with registration_context(mod_name):
-            try:
-                # Importing modules adds undesired handlers to
-                # the root logger.
-                # We will backup the handlers and updates them
-                # after importing
-                backup_handlers = logging.root.handlers[:]
+        try:
+            # Importing modules adds undesired handlers to
+            # the root logger.
+            # We will backup the handlers and updates them
+            # after importing
+            backup_handlers = logging.root.handlers[:]
 
-                importlib.import_module(mod_name)
+            importlib.import_module(mod_name)
 
-                # Remove all existing root handlers and
-                # re-apply the backed up root handlers
-                for x in logging.root.handlers[:]:
-                    logging.root.removeHandler(x)
-                for x in backup_handlers:
-                    logging.root.addHandler(x)
+            # Remove all existing root handlers and
+            # re-apply the backed up root handlers
+            for x in logging.root.handlers[:]:
+                logging.root.removeHandler(x)
+            for x in backup_handlers:
+                logging.root.addHandler(x)
 
-                logger.info(cl.YE(f"Imported extensions {mod_name}"))
-            except ModuleNotFoundError as e:
-                raise ImportError(
-                    f"Error importing {mod_name}: {e}. Please 'pip install' " +
-                    "the package manually or use '-i' flag (only applies when running " +
-                    "flambe as cmd line program)"
-                )
+            logger.info(cl.YE(f"Imported extensions {mod_name}"))
+        except ModuleNotFoundError as e:
+            raise ImportError(
+                f"Error importing {mod_name}: {e}. Please 'pip install' " +
+                "the package manually or use '-i' flag (only applies when running " +
+                "flambe as cmd line program)"
+            )
 
 
 def setup_default_modules():
     from flambe.compile.utils import make_component
     import torch
     import ray
-    TORCH_TAG_PREFIX = "torch"
-    TUNE_TAG_PREFIX = "tune"
-    make_component(torch.nn.Module, TORCH_TAG_PREFIX, only_module='torch.nn')
-    make_component(torch.optim.Optimizer, TORCH_TAG_PREFIX, only_module='torch.optim')
+    make_component(torch.nn.Module, only_module='torch.nn')
+    make_component(torch.optim.Optimizer, only_module='torch.optim')
     make_component(torch.optim.lr_scheduler._LRScheduler,
-                   TORCH_TAG_PREFIX, only_module='torch.optim.lr_scheduler')
-    make_component(ray.tune.schedulers.TrialScheduler, TUNE_TAG_PREFIX)
-    make_component(ray.tune.suggest.SearchAlgorithm, TUNE_TAG_PREFIX)
+                   only_module='torch.optim.lr_scheduler')
+    make_component(ray.tune.schedulers.TrialScheduler)
+    make_component(ray.tune.suggest.SearchAlgorithm)

--- a/flambe/compile/extensions.py
+++ b/flambe/compile/extensions.py
@@ -13,7 +13,6 @@ import subprocess
 import importlib
 import importlib.util
 from typing import Dict, Optional, Iterable
-from flambe.compile.registrable import registration_context
 from flambe.logging import coloredlogs as cl
 from flambe.compile.utils import _is_url
 

--- a/flambe/compile/registrable.py
+++ b/flambe/compile/registrable.py
@@ -84,7 +84,7 @@ class Registrable(ABC):
     adding a constructor and representer which can be overridden
     """
 
-    _yaml_tags: Dict[Type, List[str]] = defaultdict(list)
+    _yaml_tags: Dict[Any, List[str]] = defaultdict(list)
     _yaml_tag_namespace: Dict[Type, str] = defaultdict(str)
     _yaml_registered_factories: Set[str] = set()
 

--- a/flambe/compile/registrable.py
+++ b/flambe/compile/registrable.py
@@ -174,6 +174,9 @@ class Registrable(ABC):
 
         registration_helper()
         for factory_name in class_._yaml_registered_factories:
+            # Add factory tag to registry
+            factory_full_tag = f'{full_tag}.{factory_name}'
+            class_._yaml_tags[(class_, factory_name)] = [factory_full_tag]
             # Every time we register a new tag, make sure that you can
             # use each factory with that new tag
             registration_helper(factory_name)

--- a/flambe/compile/registrable.py
+++ b/flambe/compile/registrable.py
@@ -108,13 +108,13 @@ class Registrable(ABC):
     @staticmethod
     def register_tag(class_: RT, tag: str, tag_namespace: Optional[str] = None) -> None:
         # Create a tag that includes namespace e.g. `!torch.Adam`
-        global _reg_prefix
-        if _reg_prefix is not None:
-            if tag_namespace is not None:
-                full_tag = f"!{_reg_prefix}.{tag_namespace}.{tag}"
-            else:
-                full_tag = f"!{_reg_prefix}.{tag}"
-        elif tag_namespace is not None:
+        # Override any namespace as module name, now that we no longer
+        # allow user-defined namespaces
+        modules = class_.__module__.split('.')
+        top_level_module_name = modules[0] if len(modules) > 0 else None
+        if top_level_module_name is not None and top_level_module_name != 'flambe':
+            tag_namespace = top_level_module_name
+        if tag_namespace is not None:
             full_tag = f"!{tag_namespace}.{tag}"
         else:
             full_tag = f"!{tag}"

--- a/flambe/compile/utils.py
+++ b/flambe/compile/utils.py
@@ -24,7 +24,9 @@ def all_subclasses(class_: Type[Any]) -> Set[Type[Any]]:
     return set(class_.__subclasses__()).union(subsubclasses)
 
 
-def make_component(class_: type, tag_namespace: str, only_module: Optional[str] = None) -> None:
+def make_component(class_: type,
+                   tag_namespace: Optional[str] = None,
+                   only_module: Optional[str] = None) -> None:
     """Make class and all its children a `Component`
 
     For example a call to `make_component(torch.optim.Adam, "torch")`

--- a/flambe/field/label.py
+++ b/flambe/field/label.py
@@ -46,7 +46,7 @@ class LabelField(Field):
         else:
             self.label_given = False
             self.vocab = odict()
-            self.label_count_dict: Dict[str, int] = dict()
+            self.label_count_dict = dict()
 
         self.register_attrs('vocab')
         self.register_attrs('label_count_dict')

--- a/flambe/field/label.py
+++ b/flambe/field/label.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Sequence
+from typing import Optional, Sequence
 from collections import OrderedDict as odict
 
 import torch

--- a/flambe/runner/run.py
+++ b/flambe/runner/run.py
@@ -38,14 +38,14 @@ def main(args: argparse.Namespace) -> None:
         print(cl.BL(f"VERSION: {flambe.__version__}\n"))
 
     # Pass original module for ray / pickle
-    make_component(torch.nn.Module, TORCH_TAG_PREFIX, only_module='torch.nn')
+    make_component(torch.nn.Module, only_module='torch.nn')
     # torch.optim.Optimizer exists, ignore mypy
-    make_component(torch.optim.Optimizer, TORCH_TAG_PREFIX,  # type: ignore
+    make_component(torch.optim.Optimizer,  # type: ignore
                    only_module='torch.optim')
     make_component(torch.optim.lr_scheduler._LRScheduler,
-                   TORCH_TAG_PREFIX, only_module='torch.optim.lr_scheduler')
-    make_component(ray.tune.schedulers.TrialScheduler, TUNE_TAG_PREFIX)
-    make_component(ray.tune.suggest.SearchAlgorithm, TUNE_TAG_PREFIX)
+                   only_module='torch.optim.lr_scheduler')
+    make_component(ray.tune.schedulers.TrialScheduler)
+    make_component(ray.tune.suggest.SearchAlgorithm)
 
     # TODO check first if there is cluster as if there is there
     # is no need to install extensions

--- a/tests/data/dummy_configs/wrong_config.yaml
+++ b/tests/data/dummy_configs/wrong_config.yaml
@@ -5,7 +5,7 @@ name: sst-text-classification-lstm
 save_path: flambe_text_classification
 
 schedulesr:
-  b1: !tune.HyperBandScheduler
+  b1: !ray.HyperBandScheduler
     reward_attr: dev_metric
 
 redcue:

--- a/tests/integration/examples/experiments/chain_intrablock.yaml
+++ b/tests/integration/examples/experiments/chain_intrablock.yaml
@@ -66,7 +66,7 @@ pipeline:
       batch_size: 512
 
 schedulers: # Define how to schedule variants based on a metric
-  b2: !tune.HyperBandScheduler
+  b2: !ray.HyperBandScheduler
     reward_attr: dev_metric # This should be an attribute on the Trainer class
 reduce: # Only use the best variant in subsequent blocks
   b2: 1


### PR DESCRIPTION
Because of a few problems we've seen with loading classes under the wrong namespaces, this PR changes all registrations (outside of the flambe package) to automatically use the top-level module name as the prefix unless another namespace is explicitly specified. We ignore the registration context manager. These are the minimal changes needed to fix the issues we've seen; in a future PR we will refactor the registry and remove all lingering code from the earlier implementation.

Note: this PR also changes the prefix `tune` to `ray` for consistency with all other extensions.