### PR TITLE
MNIST Dataset and ImageClassifier

### DIFF
--- a/flambe/field/label.py
+++ b/flambe/field/label.py
@@ -109,7 +109,7 @@ class LabelField(Field):
             out = [int(i in out) for i in range(len(self.vocab))]
             out = torch.tensor(out).long()  # Back to Tensor
 
-        return out
+        return out.squeeze()
 
     @property
     def vocab_size(self) -> int:

--- a/flambe/nn/mlp.py
+++ b/flambe/nn/mlp.py
@@ -57,7 +57,8 @@ class MLPEncoder(Module):
 
             # Add the first hidden layer
             layers.append(nn.Linear(input_size, hidden_size))
-            layers.append(hidden_activation)
+            if hidden_activation is not None:
+                layers.append(hidden_activation)
 
             for _ in range(1, n_layers - 1):
                 layers.append(nn.Linear(hidden_size, hidden_size))

--- a/flambe/sampler/base.py
+++ b/flambe/sampler/base.py
@@ -177,7 +177,7 @@ def collate_fn(data: List[Tuple[torch.Tensor, ...]],
             sizes = [tensor.size() for tensor in tensors]
 
             if all(s == sizes[0] for s in sizes):
-                stacked_tensors = torch.stack(tensors).squeeze(1)
+                stacked_tensors = torch.stack(tensors)
                 batch.append(stacked_tensors)
             else:
                 # Variable length sequences

--- a/flambe/vision/__init__.py
+++ b/flambe/vision/__init__.py
@@ -1,0 +1,3 @@
+from flambe.vision import classification
+
+__all__ = ['classification']

--- a/flambe/vision/classification/__init__.py
+++ b/flambe/vision/classification/__init__.py
@@ -1,0 +1,3 @@
+from flambe.vision.classification.datasets import MNISTDataset
+
+__all__ = ['MNISTDataset']

--- a/flambe/vision/classification/__init__.py
+++ b/flambe/vision/classification/__init__.py
@@ -1,3 +1,4 @@
 from flambe.vision.classification.datasets import MNISTDataset
+from flambe.vision.classification.model import ImageClassifier
 
-__all__ = ['MNISTDataset']
+__all__ = ['MNISTDataset', 'ImageClassifier']

--- a/flambe/vision/classification/datasets.py
+++ b/flambe/vision/classification/datasets.py
@@ -1,0 +1,153 @@
+import gzip
+import torch
+import requests
+from typing import List, Tuple, Optional
+
+from sklearn.model_selection import train_test_split
+
+import numpy as np
+
+from flambe.dataset import Dataset
+from flambe.compile import registrable_factory
+
+
+class MNISTDataset(Dataset):
+    """The official MNIST dataset."""
+
+    data_type = {
+        0x08: np.uint8,
+        0x09: np.int8,
+        0x0b: np.dtype('>i2'),
+        0x0c: np.dtype('>i4'),
+        0x0d: np.dtype('>f4'),
+        0x0e: np.dtype('>f8'),
+    }
+
+    URL = "http://yann.lecun.com/exdb/mnist/"
+
+    def __init__(self,
+                 train_images: np.ndarray = None,
+                 train_labels: np.ndarray = None,
+                 test_images: np.ndarray = None,
+                 test_labels: np.ndarray = None,
+                 val_ratio: Optional[float] = 0.2,
+                 seed: Optional[int] = None) -> None:
+        """Initialize the MNISTDataset.
+
+        Parameters
+        ----------
+        train_images: np.ndarray
+            parsed train images as a numpy array
+        train_labels: np.ndarray
+            parsed train labels as a numpy array
+        test_images: np.ndarray
+            parsed test images as a numpy array
+        test_labels: np.ndarray
+            parsed test labels as a numpy array
+        val_ratio: Optional[float]
+            validation set ratio. Default 0.2
+        seed: Optional[int]
+            random seed for the validation set split
+        """
+        if train_images is None:
+            train_images = self._parse_downloaded_idx(self.URL + "train-images-idx3-ubyte.gz")
+        if train_labels is None:
+            train_labels = self._parse_downloaded_idx(self.URL + "train-labels-idx1-ubyte.gz")
+        if test_images is None:
+            test_images = self._parse_downloaded_idx(self.URL + "t10k-images-idx3-ubyte.gz")
+        if test_labels is None:
+            test_labels = self._parse_downloaded_idx(self.URL + "t10k-labels-idx1-ubyte.gz")
+
+        self.train_images, self.val_images, self.train_labels, self.val_labels = \
+            train_test_split(train_images, train_labels, test_size=val_ratio, random_state=seed)
+        self.test_images = test_images
+        self.test_labels = test_labels
+
+        self._train = get_dataset(self.train_images, self.train_labels)
+        self._val = get_dataset(self.val_images, self.val_labels)
+        self._test = get_dataset(self.test_images, self.test_labels)
+
+    @registrable_factory
+    @classmethod
+    def from_path(cls,
+                  train_images_path: str,
+                  train_labels_path: str,
+                  test_images_path: str,
+                  test_labels_path: str,
+                  val_ratio: Optional[float] = 0.2,
+                  seed: Optional[int] = None) -> 'MNISTDataset':
+        """Initialize the MNISTDataset from local files.
+
+        Parameters
+        ----------
+        train_images_path: str
+            path to the train images file in the idx format
+        train_labels_path: str
+            path to the train labels file in the idx format
+        test_images_path: str
+            path to the test images file in the idx format
+        test_labels_path: str
+            path to the test labels file in the idx format
+        val_ratio: Optional[float]
+            validation set ratio. Default 0.2
+        seed: Optional[int]
+            random seed for the validation set split
+        """
+        return cls(
+            cls._parse_local_gzipped_idx(train_images_path),
+            cls._parse_local_gzipped_idx(train_labels_path),
+            cls._parse_local_gzipped_idx(test_images_path),
+            cls._parse_local_gzipped_idx(test_labels_path),
+            val_ratio=val_ratio,
+            seed=seed,
+        )
+
+    @property
+    def train(self) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+        """Returns the training data"""
+        return self._train
+
+    @property
+    def val(self) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+        """Returns the validation data"""
+        return self._val
+
+    @property
+    def test(self) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+        """Returns the test data"""
+        return self._test
+
+    @classmethod
+    def _parse_local_gzipped_idx(cls, path: str) -> np.ndarray:
+        """Parse a local gzipped idx file"""
+        with gzip.open(path) as f:
+            return cls._parse_idx(f.read())
+
+    @classmethod
+    def _parse_downloaded_idx(cls, url: str) -> np.ndarray:
+        """Parse a downloaded idx file"""
+        r = requests.get(url)
+        return cls._parse_idx(gzip.decompress(r.content))
+
+    @classmethod
+    def _parse_idx(cls, data: bytes) -> np.ndarray:
+        """Parse an idx filie"""
+        # parse the magic number that contains the dimension
+        # and the data type
+        magic = int.from_bytes(data[0:4], 'big')
+        dim = magic % 256
+        data_type = magic // 256
+
+        shape = [int.from_bytes(data[4 * (i + 1): 4 * (i + 2)], 'big') for i in range(dim)]
+        return np.frombuffer(
+            data,
+            dtype=cls.data_type[data_type],
+            offset=4 * (dim + 1)
+        ).reshape(shape)
+
+
+def get_dataset(images: np.ndarray, labels: np.ndarray) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+    return [(
+        torch.from_numpy(image).float().unsqueeze(0),
+        torch.tensor(label).long()
+    ) for image, label in zip(images, labels)]

--- a/flambe/vision/classification/model.py
+++ b/flambe/vision/classification/model.py
@@ -1,0 +1,50 @@
+import torch
+from torch import Tensor
+
+from typing import Optional, Tuple, Union
+from flambe.nn import Module
+
+
+class ImageClassifier(Module):
+    """Implements a simple image classifier.
+
+    This classifier consists of an encocder module, followed by
+    a fully connected output layer that outputs a probability
+    distribution.
+
+    Attributes
+    ----------
+    encoder: Moodule
+        The encoder layer
+    output_layer: Module
+        The output layer, yields a probability distribution over targets
+    """
+    def __init__(self,
+                 encoder: Module,
+                 output_layer: Module) -> None:
+        super().__init__()
+
+        self.encoder = encoder
+        self.output_layer = output_layer
+
+    def forward(self,
+                data: Tensor,
+                target: Optional[Tensor] = None) -> Union[Tensor, Tuple[Tensor, Tensor]]:
+        """Run a forward pass through the network.
+
+        Parameters
+        ----------
+        data: Tensor
+            The input data
+        target: Tensor, optional
+            The input targets, optional
+
+        Returns
+        -------
+        Union[Tensor, Tuple[Tensor, Tensor]
+            The output predictions, and optionally the targets
+
+        """
+        encoded = self.encoder(data)
+        pred = self.output_layer(torch.flatten(encoded, 1))
+        return (pred, target) if target is not None else pred

--- a/tests/integration/test_ic_temp.py
+++ b/tests/integration/test_ic_temp.py
@@ -1,0 +1,46 @@
+import pytest
+import tempfile
+import subprocess
+
+
+@pytest.mark.integration
+def test_image_classification_config():
+    config = """
+!Experiment
+
+name: image_classification
+save_path: .
+
+pipeline:
+  model: !ImageClassifier
+    encoder: !CNNEncoder
+      input_channels: 1
+      channels: [1]
+      kernel_size: [5]
+    output_layer: !MLPEncoder
+      input_size: 576
+      n_layers: 2
+      output_size: 10
+      output_activation: !torch.LogSoftmax
+      hidden_size: 128
+
+  train: !Trainer
+    dataset: !MNISTDataset
+    train_sampler: !BaseSampler
+      batch_size: 64
+    val_sampler: !BaseSampler
+    model: !@ model
+    loss_fn: !torch.NLLLoss
+    metric_fn: !Accuracy
+    optimizer: !torch.Adam
+      params: !@ train[model].trainable_params
+    max_steps: 1
+    iter_per_step: 1
+"""
+
+    with tempfile.TemporaryDirectory() as d, tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+        exp = config.format(d)
+        f.write(exp)
+        f.flush()
+        ret = subprocess.run(['flambe', f.name])
+        assert ret.returncode == 0

--- a/tests/unit/field/test_label_field.py
+++ b/tests/unit/field/test_label_field.py
@@ -45,9 +45,9 @@ def test_label_process():
     field.setup(dummy)
 
     assert len(field.vocab) == 3
-    assert list(field.process('LABEL1')) == [0]
-    assert list(field.process('LABEL2')) == [2]
-    assert list(field.process('LABEL3')) == [1]
+    assert int(field.process('LABEL1')) == 0
+    assert int(field.process('LABEL2')) == 2
+    assert int(field.process('LABEL3')) == 1
 
 
 def test_label_process_multilabel():
@@ -64,8 +64,8 @@ def test_label_process_multilabel():
 
     assert list(field.process('LABEL1,LABEL2')) == [0, 1]
     assert list(field.process('LABEL2,LABEL1')) == [1, 0]
-    assert list(field.process('LABEL2')) == [1]
-    assert list(field.process('LABEL3')) == [2]
+    assert int(field.process('LABEL2')) == 1
+    assert int(field.process('LABEL3')) == 2
 
 
 def test_label_process_one_hot():
@@ -205,15 +205,15 @@ def test_pass_bool_labels():
     field.setup(dummy)
 
     assert len(field.vocab) == 2
-    assert list(field.process(False)) == [0]
-    assert list(field.process(True)) == [1]
+    assert int(field.process(False)) == 0
+    assert int(field.process(True)) == 1
 
     field = LabelField(labels=[True, False])
     field.setup(dummy)
 
     assert len(field.vocab) == 2
-    assert list(field.process(False)) == [1]
-    assert list(field.process(True)) == [0]
+    assert int(field.process(False)) == 1
+    assert int(field.process(True)) == 0
 
 
 def test_pass_labels():
@@ -224,17 +224,17 @@ def test_pass_labels():
     field.setup(dummy)
 
     assert len(field.vocab) == 3
-    assert list(field.process('LABEL1')) == [0]
-    assert list(field.process('LABEL2')) == [1]
-    assert list(field.process('LABEL3')) == [2]
+    assert int(field.process('LABEL1')) == 0
+    assert int(field.process('LABEL2')) == 1
+    assert int(field.process('LABEL3')) == 2
 
     field = LabelField(labels=['LABEL3', 'LABEL1', 'LABEL2'])
     field.setup(dummy)
 
     assert len(field.vocab) == 3
-    assert list(field.process('LABEL1')) == [1]
-    assert list(field.process('LABEL2')) == [2]
-    assert list(field.process('LABEL3')) == [0]
+    assert int(field.process('LABEL1')) == 1
+    assert int(field.process('LABEL2')) == 2
+    assert int(field.process('LABEL3')) == 0
 
 
 def test_pass_labels_with_unkown_1():

--- a/tests/unit/nn/test_mlp.py
+++ b/tests/unit/nn/test_mlp.py
@@ -1,0 +1,59 @@
+from flambe.nn import MLPEncoder
+import torch
+
+
+def test_forward_pass_1_layer():
+    input_size = 128
+    output_size = 64
+    batch_size = 32
+
+    # no activation
+    mlp_enc = MLPEncoder(input_size, output_size)
+    _in = torch.rand((batch_size, input_size))
+    out = mlp_enc(_in)
+
+    assert out.shape == torch.Size((batch_size, output_size))
+
+    # with activation
+    mlp_enc = MLPEncoder(
+        input_size,
+        output_size,
+        output_activation=torch.nn.ReLU(),
+    )
+    _in = torch.rand((batch_size, input_size))
+    out = mlp_enc(_in)
+
+    assert out.shape == torch.Size((batch_size, output_size))
+
+
+def test_forward_pass_multi_layers():
+    input_size = 256
+    hidden_size = 128
+    output_size = 64
+    batch_size = 32
+
+    # no activation
+    mlp_enc = MLPEncoder(
+        input_size,
+        output_size,
+        n_layers=3,
+        hidden_size=hidden_size,
+    )
+    _in = torch.rand((batch_size, input_size))
+    out = mlp_enc(_in)
+
+    assert out.shape == torch.Size((batch_size, output_size))
+
+    # with activation
+    mlp_enc = MLPEncoder(
+        input_size,
+        output_size,
+        n_layers=3,
+        output_activation=torch.nn.ReLU(),
+        hidden_size=hidden_size,
+        hidden_activation=torch.nn.ReLU(),
+    )
+    _in = torch.rand((batch_size, input_size))
+    out = mlp_enc(_in)
+
+    assert out.shape == torch.Size((batch_size, output_size))


### PR DESCRIPTION
All the commits included in this PR should be self-contained and easy to read one by one.

The first two commits fix some bugs I encountered along the way. The fix on `BaseSampler` may have unexpected consequences on other experiments, so let me know if there is another way to fix the issue.

Sample Experiment:
```yaml
!Experiment

name: mnist
resources:
  local:
    train_images: train-images-idx3-ubyte.gz
    train_labels: train-labels-idx1-ubyte.gz
    test_images: t10k-images-idx3-ubyte.gz
    test_labels: t10k-labels-idx1-ubyte.gz

pipeline:
  dataset: !MNISTDataset.from_path
    train_images_path: !@ train_images
    train_labels_path: !@ train_labels
    test_images_path: !@ test_images
    test_labels_path: !@ test_labels
  # or simply to download
  # dataset: !MNISTDataset.download

  model: !ImageClassifier
    encoder: !CNNEncoder
      input_channels: 1
      channels: [10, 20]
      kernel_size: [5, 5]
    linear: !MLPEncoder
      input_size: 8000  # 20 * 20 * 20
      output_size: 2048
      # output_activation: !torch.ReLU   <- due to https://github.com/asappresearch/flambe/issues/65, I could not set the activation layer
      n_layers: 2
      hidden_size: 4096
      # hidden_activation: !torch.ReLU   <- due to https://github.com/asappresearch/flambe/issues/65, I could not set the activation layer
    output_layer: !SoftmaxLayer
      input_size: 2048
      output_size: 10

  train: !Trainer
    dataset: !@ dataset
    train_sampler: !BaseSampler
      batch_size: 64
    val_sampler: !BaseSampler
    model: !@ model
    loss_fn: !torch.NLLLoss
    metric_fn: !Accuracy
    optimizer: !torch.Adam
      params: !@ train.model.trainable_params
    max_steps: 20
    iter_per_step: 50

```