### PR TITLE
make everything batch first

### DIFF
--- a/flambe/nn/pooling.py
+++ b/flambe/nn/pooling.py
@@ -26,7 +26,7 @@ class FirstPooling(Module):
             The output data, as a tensor of shape [B x H]
 
         """
-        return data[0, :, :]
+        return data[:, 0, :]
 
 
 class LastPooling(Module):
@@ -54,9 +54,9 @@ class LastPooling(Module):
         if padding_mask is None:
             lengths = torch.tensor([data.size(0)] * data.size(1)).long()
         else:
-            lengths = padding_mask.long().sum(dim=0)
+            lengths = padding_mask.long().sum(dim=1)
 
-        return data[lengths - 1, torch.arange(data.size(1)).long(), :]
+        return data[torch.arange(data.size(1)).long(), lengths - 1, :]
 
 
 class SumPooling(Module):
@@ -70,9 +70,9 @@ class SumPooling(Module):
         Parameters
         ----------
         data : torch.Tensor
-            The input data, as a tensor of shape [S x B x H]
+            The input data, as a tensor of shape [B x S x H]
         padding_mask: torch.Tensor
-            The input mask, as a tensor of shape [S X B]
+            The input mask, as a tensor of shape [B X S]
 
         Returns
         ----------
@@ -84,7 +84,7 @@ class SumPooling(Module):
         if padding_mask is None:
             padding_mask = torch.ones((data.size(0), data.size(1))).to(data)
 
-        return (data * padding_mask.unsqueeze(2)).sum(dim=0)
+        return (data * padding_mask.unsqueeze(2)).sum(dim=1)
 
 
 class AvgPooling(Module):
@@ -98,9 +98,9 @@ class AvgPooling(Module):
         Parameters
         ----------
         data : torch.Tensor
-            The input data, as a tensor of shape [S x B x H]
+            The input data, as a tensor of shape [B x S x H]
         padding_mask: torch.Tensor
-            The input mask, as a tensor of shape [S X B]
+            The input mask, as a tensor of shape [B X S]
 
         Returns
         ----------
@@ -112,5 +112,5 @@ class AvgPooling(Module):
         if padding_mask is None:
             padding_mask = torch.ones((data.size(0), data.size(1))).to(data)
 
-        data = (data * padding_mask.unsqueeze(2)).sum(dim=0)
-        return data / padding_mask.sum(dim=0)
+        data = (data * padding_mask.unsqueeze(2)).sum(dim=1)
+        return data / padding_mask.sum(dim=1)

--- a/flambe/nn/rnn.py
+++ b/flambe/nn/rnn.py
@@ -117,9 +117,9 @@ class RNNEncoder(Module):
             The encoded state, as a float tensor of shape [L x B x H]
 
         """
-        data = data.transpose(0, 1)
+        data = data.t()
         if padding_mask is not None:
-            padding_mask = padding_mask.transpose(0, 1)
+            padding_mask = padding_mask.t()
 
         if padding_mask is None:
             # Default RNN behavior
@@ -138,7 +138,7 @@ class RNNEncoder(Module):
             output, _ = nn.utils.rnn.pad_packed_sequence(output)
 
         # TODO investigate why PyTorch returns type Any for output
-        return output.transpose(0, 1), state  # type: ignore
+        return output.t(), state  # type: ignore
 
 
 class PooledRNNEncoder(Module):
@@ -238,9 +238,9 @@ class PooledRNNEncoder(Module):
             padding_mask = torch.ones_like(output)
 
         # Make batch first
-        output = output.transpose(0, 1)
+        output = output.t()
         cast(torch.Tensor, padding_mask)
-        padding_mask = padding_mask.transpose(0, 1).float()
+        padding_mask = padding_mask.t().float()
 
         if self.pooling == 'average':
             output = (output * padding_mask.unsqueeze(2)).sum(dim=1)

--- a/flambe/nn/rnn.py
+++ b/flambe/nn/rnn.py
@@ -103,20 +103,24 @@ class RNNEncoder(Module):
         Parameters
         ----------
         data : Tensor
-            The input data, as a float tensor of shape [S x B x E]
+            The input data, as a float tensor of shape [B x S x E]
         state: Tensor
             An optional previous state of shape [L x B x H]
         padding_mask: Tensor, optional
-            The padding mask of shape [S x B]
+            The padding mask of shape [B x S]
 
         Returns
         -------
         Tensor
-            The encoded output, as a float tensor of shape [S x B x H]
+            The encoded output, as a float tensor of shape [B x S x H]
         Tensor
             The encoded state, as a float tensor of shape [L x B x H]
 
         """
+        data = data.transpose(0, 1)
+        if padding_mask is not None:
+            padding_mask = padding_mask.transpose(0, 1)
+
         if padding_mask is None:
             # Default RNN behavior
             output, state = self.rnn(data, state)
@@ -134,7 +138,7 @@ class RNNEncoder(Module):
             output, _ = nn.utils.rnn.pad_packed_sequence(output)
 
         # TODO investigate why PyTorch returns type Any for output
-        return output, state  # type: ignore
+        return output.transpose(0, 1), state  # type: ignore
 
 
 class PooledRNNEncoder(Module):

--- a/flambe/nn/rnn.py
+++ b/flambe/nn/rnn.py
@@ -117,9 +117,9 @@ class RNNEncoder(Module):
             The encoded state, as a float tensor of shape [L x B x H]
 
         """
-        data = data.t()
+        data = data.transpose(0, 1)
         if padding_mask is not None:
-            padding_mask = padding_mask.t()
+            padding_mask = padding_mask.transpose(0, 1)
 
         if padding_mask is None:
             # Default RNN behavior
@@ -138,7 +138,7 @@ class RNNEncoder(Module):
             output, _ = nn.utils.rnn.pad_packed_sequence(output)
 
         # TODO investigate why PyTorch returns type Any for output
-        return output.t(), state  # type: ignore
+        return output.transpose(0, 1).contiguous(), state  # type: ignore
 
 
 class PooledRNNEncoder(Module):
@@ -219,11 +219,11 @@ class PooledRNNEncoder(Module):
         Parameters
         ----------
         data : torch.Tensor
-            The input data, as a float tensor of shape [S x B x E]
+            The input data, as a float tensor of shape [B x S x E]
         state: Tensor
             An optional previous state of shape [L x B x H]
         padding_mask: Tensor, optional
-            The padding mask of shape [S x B]
+            The padding mask of shape [B x S]
 
         Returns
         -------
@@ -237,11 +237,7 @@ class PooledRNNEncoder(Module):
         if padding_mask is None:
             padding_mask = torch.ones_like(output)
 
-        # Make batch first
-        output = output.t()
         cast(torch.Tensor, padding_mask)
-        padding_mask = padding_mask.t().float()
-
         if self.pooling == 'average':
             output = (output * padding_mask.unsqueeze(2)).sum(dim=1)
             output = output / padding_mask.sum(dim=1)

--- a/flambe/nn/transformer.py
+++ b/flambe/nn/transformer.py
@@ -514,7 +514,7 @@ class TransformerDecoderLayer(Module):
         """
         # Transpose anr reverse
         if padding_mask is not None:
-            padding_mask = (-padding_mask + 1).t()
+            padding_mask = (-padding_mask + 1)
 
         tgt2 = self.self_attn(tgt, tgt, tgt, attn_mask=tgt_mask,
                               key_padding_mask=padding_mask)[0]
@@ -537,6 +537,6 @@ def generate_square_subsequent_mask(self, sz):
     The masked positions are filled with float('-inf').
     Unmasked positions are filled with float(0.0).
     """
-    mask = (torch.triu(torch.ones(sz, sz)) == 1).transpose(0, 1)
+    mask = (torch.triu(torch.ones(sz, sz)) == 1).t()
     mask = mask.float().masked_fill(mask == 0, float('-inf')).masked_fill(mask == 1, float(0.0))
     return mask

--- a/flambe/nn/transformer.py
+++ b/flambe/nn/transformer.py
@@ -228,7 +228,7 @@ class TransformerEncoder(Module):
             for padding tokens.
 
         """
-        output = src.t()
+        output = src.transpose(0, 1)
 
         if self.input_size != self.d_model:
             output = self.proj(output)
@@ -239,7 +239,7 @@ class TransformerEncoder(Module):
                                     src_mask=mask,
                                     padding_mask=padding_mask)
 
-        return output.t()
+        return output.transpose(0, 1)
 
     def _reset_parameters(self):
         """Initiate parameters in the transformer model."""
@@ -326,7 +326,7 @@ class TransformerDecoder(Module):
         torch.Tensor
 
         """
-        output = tgt.t()
+        output = tgt.transpose(0, 1)
 
         if self.input_size != self.d_model:
             output = self.proj(output)
@@ -339,7 +339,7 @@ class TransformerDecoder(Module):
                                     padding_mask=padding_mask,
                                     memory_key_padding_mask=memory_key_padding_mask)
 
-        return output.t()
+        return output.transpose(0, 1)
 
     def _reset_parameters(self):
         """Initiate parameters in the transformer model."""

--- a/flambe/nn/transformer.py
+++ b/flambe/nn/transformer.py
@@ -91,10 +91,10 @@ class Transformer(Module):
         ----------
         src: torch.Tensor
             the sequence to the encoder (required).
-            shape: :math:`(S, N, E)`.
+            shape: :math:`(N, S, E)`.
         tgt: torch.Tensor
             the sequence to the decoder (required).
-            shape: :math:`(T, N, E)`.
+            shape: :math:`(N, T, E)`.
         src_mask: torch.Tensor, optional
             the additive mask for the src sequence (optional).
             shape: :math:`(S, S)`.
@@ -117,7 +117,7 @@ class Transformer(Module):
         Returns
         -------
         output: torch.Tensor
-            The output sequence, shape: :math:`(T, N, E)`.
+            The output sequence, shape: :math:`(N, T, E)`.
 
         Note: [src/tgt/memory]_mask should be filled with
             float('-inf') for the masked positions and float(0.0) else.
@@ -217,7 +217,7 @@ class TransformerEncoder(Module):
         Parameters
         ----------
         src: torch.Tensor
-            The sequnce to the encoder (required).
+            The sequence to the encoder (required).
         memory: torch.Tensor, optional
             Optional memory, unused by default.
         mask: torch.Tensor, optional
@@ -228,7 +228,7 @@ class TransformerEncoder(Module):
             for padding tokens.
 
         """
-        output = src
+        output = src.t()
 
         if self.input_size != self.d_model:
             output = self.proj(output)
@@ -239,7 +239,7 @@ class TransformerEncoder(Module):
                                     src_mask=mask,
                                     padding_mask=padding_mask)
 
-        return output
+        return output.t()
 
     def _reset_parameters(self):
         """Initiate parameters in the transformer model."""
@@ -326,7 +326,7 @@ class TransformerDecoder(Module):
         torch.Tensor
 
         """
-        output = tgt
+        output = tgt.t()
 
         if self.input_size != self.d_model:
             output = self.proj(output)
@@ -339,7 +339,7 @@ class TransformerDecoder(Module):
                                     padding_mask=padding_mask,
                                     memory_key_padding_mask=memory_key_padding_mask)
 
-        return output
+        return output.t()
 
     def _reset_parameters(self):
         """Initiate parameters in the transformer model."""
@@ -414,12 +414,12 @@ class TransformerEncoderLayer(Module):
         Returns
         -------
         torch.Tensor
-            Output tensor of shape [S x B x H]
+            Output tensor of shape [B x S x H]
 
         """
-        # Transpose anr reverse
+        # Transpose and reverse
         if padding_mask is not None:
-            padding_mask = (-padding_mask + 1).t()
+            padding_mask = (-padding_mask + 1)
 
         src2 = self.self_attn(src, src, src, attn_mask=src_mask,
                               key_padding_mask=padding_mask)[0]

--- a/flambe/nn/transformer_sru.py
+++ b/flambe/nn/transformer_sru.py
@@ -246,7 +246,7 @@ class TransformerSRUEncoder(Module):
             for padding tokens.
 
         """
-        output = src.t()
+        output = src.transpose(0, 1)
 
         if self.input_size != self.d_model:
             output = self.proj(output)
@@ -261,7 +261,7 @@ class TransformerSRUEncoder(Module):
             new_states.append(new_state)
 
         new_states = torch.stack(new_states, dim=0)
-        return output.t(), new_states
+        return output.transpose(0, 1), new_states
 
     def _reset_parameters(self):
         """Initiate parameters in the transformer model."""
@@ -364,7 +364,7 @@ class TransformerSRUDecoder(Module):
         torch.Tensor
 
         """
-        output = tgt.t()
+        output = tgt.transpose(0, 1)
         state = state or [None] * self.num_layers
 
         if self.input_size != self.d_model:
@@ -379,7 +379,7 @@ class TransformerSRUDecoder(Module):
                                     padding_mask=padding_mask,
                                     memory_key_padding_mask=memory_key_padding_mask)
 
-        return output.t()
+        return output.transpose(0, 1)
 
     def _reset_parameters(self):
         """Initiate parameters in the transformer model."""

--- a/flambe/nn/transformer_sru.py
+++ b/flambe/nn/transformer_sru.py
@@ -471,7 +471,7 @@ class TransformerSRUEncoderLayer(Module):
         # Transpose and reverse
         reversed_mask = None
         if padding_mask is not None:
-            reversed_mask = (-padding_mask + 1).t()
+            reversed_mask = (-padding_mask + 1)
 
         src2 = self.self_attn(src, src, src, attn_mask=src_mask,
                               key_padding_mask=reversed_mask)[0]
@@ -571,7 +571,7 @@ class TransformerSRUDecoderLayer(Module):
         # Transpose and reverse
         reversed_mask = None
         if padding_mask is not None:
-            reversed_mask = (-padding_mask + 1).t()
+            reversed_mask = (-padding_mask + 1)
 
         tgt2 = self.self_attn(tgt, tgt, tgt, attn_mask=tgt_mask,
                               key_padding_mask=reversed_mask)[0]

--- a/flambe/nn/transformer_sru.py
+++ b/flambe/nn/transformer_sru.py
@@ -93,10 +93,10 @@ class TransformerSRU(Module):
         ----------
         src: torch.Tensor
             the sequence to the encoder (required).
-            shape: :math:`(S, N, E)`.
+            shape: :math:`(N, S, E)`.
         tgt: torch.Tensor
             the sequence to the decoder (required).
-            shape: :math:`(T, N, E)`.
+            shape: :math:`(N, T, E)`.
         src_mask: torch.Tensor, optional
             the additive mask for the src sequence (optional).
             shape: :math:`(S, S)`.
@@ -246,7 +246,7 @@ class TransformerSRUEncoder(Module):
             for padding tokens.
 
         """
-        output = src
+        output = src.t()
 
         if self.input_size != self.d_model:
             output = self.proj(output)
@@ -261,7 +261,7 @@ class TransformerSRUEncoder(Module):
             new_states.append(new_state)
 
         new_states = torch.stack(new_states, dim=0)
-        return output, new_states
+        return output.t(), new_states
 
     def _reset_parameters(self):
         """Initiate parameters in the transformer model."""
@@ -364,7 +364,7 @@ class TransformerSRUDecoder(Module):
         torch.Tensor
 
         """
-        output = tgt
+        output = tgt.t()
         state = state or [None] * self.num_layers
 
         if self.input_size != self.d_model:
@@ -379,7 +379,7 @@ class TransformerSRUDecoder(Module):
                                     padding_mask=padding_mask,
                                     memory_key_padding_mask=memory_key_padding_mask)
 
-        return output
+        return output.t()
 
     def _reset_parameters(self):
         """Initiate parameters in the transformer model."""

--- a/flambe/sampler/episodic.py
+++ b/flambe/sampler/episodic.py
@@ -8,7 +8,11 @@ from flambe.sampler import Sampler
 
 
 class EpisodicSampler(Sampler):
-    """Implements an EpisodicSample object."""
+    """Implement an EpisodicSample object.
+
+    Currently only supports sequence inputs.
+
+    """
 
     def __init__(self,
                  n_support: int,
@@ -16,8 +20,7 @@ class EpisodicSampler(Sampler):
                  n_episodes: int,
                  n_classes: int = None,
                  pad_index: int = 0,
-                 balance_query: bool = False,
-                 batch_first: bool = False) -> None:
+                 balance_query: bool = False) -> None:
         """Initialize the EpisodicSampler.
 
         Parameters
@@ -38,9 +41,6 @@ class EpisodicSampler(Sampler):
             If True, the same number of query points are sampled per
             class, otherwise query points are sampled uniformly
             from the input data
-        batch_first: bool, optional
-            Whether to return sequential data batch first, defaults to
-            False, meaning the sequence length is first.
 
         """
         self.pad = pad_index
@@ -51,7 +51,6 @@ class EpisodicSampler(Sampler):
         self.n_episodes = n_episodes
 
         self.balance_query = balance_query
-        self.batch_first = batch_first
 
     def sample(self,
                data: Sequence[Sequence[torch.Tensor]],
@@ -113,12 +112,12 @@ class EpisodicSampler(Sampler):
                 support_source, support_target = list(zip(*supports))
 
                 query_source = pad_sequence(query_source,
-                                            batch_first=self.batch_first,
+                                            batch_first=False,
                                             padding_value=self.pad)
                 query_target = torch.tensor(query_target)
 
                 support_source = pad_sequence(support_source,
-                                              batch_first=self.batch_first,
+                                              batch_first=False,
                                               padding_value=self.pad)
                 support_target = torch.tensor(support_target)
 

--- a/flambe/sampler/episodic.py
+++ b/flambe/sampler/episodic.py
@@ -112,12 +112,12 @@ class EpisodicSampler(Sampler):
                 support_source, support_target = list(zip(*supports))
 
                 query_source = pad_sequence(query_source,
-                                            batch_first=False,
+                                            batch_first=True,
                                             padding_value=self.pad)
                 query_target = torch.tensor(query_target)
 
                 support_source = pad_sequence(support_source,
-                                              batch_first=False,
+                                              batch_first=True,
                                               padding_value=self.pad)
                 support_target = torch.tensor(support_target)
 

--- a/tests/unit/sampler/test_base.py
+++ b/tests/unit/sampler/test_base.py
@@ -42,22 +42,21 @@ def test_compose_padded_batches_from_nested_seq():
     sampler = BaseSampler(
         batch_size=bs,
         shuffle=False,
-        pad_index=0,
-        batch_first=False
+        pad_index=0
     )
     sampler = sampler.sample(data)
 
     batch = next(sampler)
     a, b, c = batch
-    assert a.size() == (2, bs)  # In first batch, first col: largest element has length 2
-    assert b.size() == (5, 4, bs)  # In first batch, second col: largest child has length 5; largest seq. of children has length 4
-    assert c.size() == (8, 3, bs)  # In first batch, third col: largest child has length 8; largest seq. of children has length 3
+    assert a.size() == (bs, 2)  # In first batch, first col: largest element has length 2
+    assert b.size() == (bs, 4, 5)  # In first batch, second col: largest child has length 5; largest seq. of children has length 4
+    assert c.size() == (bs, 3, 8)  # In first batch, third col: largest child has length 8; largest seq. of children has length 3
 
     batch = next(sampler)
     a, b, c = batch
-    assert a.size() == (4, bs) # In second batch, first col: largest element has length 4
-    assert b.size() == (6, 2, bs)  # In first batch, second col: largest child has length 6; largest seq. of children has length 2
-    assert c.size() == (7, 1, bs)  # In first batch, third col: largest child has length 7; largest seq. of children has length 1
+    assert a.size() == (bs, 4) # In second batch, first col: largest element has length 4
+    assert b.size() == (bs, 2, 6)  # In first batch, second col: largest child has length 6; largest seq. of children has length 2
+    assert c.size() == (bs, 1, 7)  # In first batch, third col: largest child has length 7; largest seq. of children has length 1
 
 
 def test_column_specific_pad_indexes():
@@ -89,8 +88,7 @@ def test_column_specific_pad_indexes():
     sampler = BaseSampler(
         batch_size=bs,
         shuffle=False,
-        pad_index=(-2, -1, 0),
-        batch_first=False
+        pad_index=(-2, -1, 0)
     )
     sampler = sampler.sample(data)
     batch = next(sampler)
@@ -132,8 +130,7 @@ def test_incorrect_num_column_specific_pad_indexes_raises_error():
     sampler = BaseSampler(
         batch_size=bs,
         shuffle=False,
-        pad_index=(num_cols + 99) * (0,),
-        batch_first=False
+        pad_index=(num_cols + 99) * (0,)
     )
     sampler = sampler.sample(data)
     with pytest.raises(Exception):


### PR DESCRIPTION
This PR makes Flambé fully batch first, for better generalizability and addresses a bug in the BaseSampler when all elements in the batch are the same size.