### PR TITLE
fix id in PickledDataLink

### DIFF
--- a/flambe/compile/component.py
+++ b/flambe/compile/component.py
@@ -376,7 +376,7 @@ class PickledDataLink(Registrable):
         global _link_obj_stash
         obj_id = str(len(_link_obj_stash.keys()))
         _link_obj_stash[obj_id] = node.obj_value
-        return representer.represent_scalar(tag, node.obj_id)
+        return representer.represent_scalar(tag, obj_id)
 
     @classmethod
     def from_yaml(cls, constructor: Any, node: Any, factory_name: str) -> 'PickledDataLink':


### PR DESCRIPTION
This PR fixes a typo that put an outdated stash id into a PickledDataLink (the object used to serialize objects that can't be represented in YAML that are used for initialization)