### PR TITLE
Update config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ workflows:
       - publish-test:
           context: flambe-publisher
           requires:
-            - end2end
+            - test
           filters:
             tags:
               only:


### PR DESCRIPTION
Until we figure out the `end2end` tests, the publisher should depend on the `test` job.