### PR TITLE
Add missing twine install + managing env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
           - image: python:3.6
       steps:
         - checkout
+        - run: python3 -m pip install --user twine
         - run: python3 setup.py sdist bdist_wheel
         - run: twine upload --repository-url $PYPI_TEST_URL dist/*
   publish:
@@ -45,6 +46,7 @@ jobs:
           - image: python:3.6
       steps:
         - checkout
+        - run: python3 -m pip install --user twine
         - run: python3 setup.py sdist bdist_wheel
         - run: twine upload --repository-url $PYPI_URL dist/*
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
         - checkout
         - run: python3 -m pip install --user twine
         - run: python3 setup.py sdist bdist_wheel
-        - run: twine upload --repository-url $PYPI_TEST_URL dist/*
+        - run: twine upload -u $TWINE_TEST_USERNAME -p $TWINE_TEST_PASSWORD --repository-url $PYPI_TEST_URL dist/*
   publish:
       docker:
           - image: python:3.6


### PR DESCRIPTION
Add missing `pip install twine` and manages env vars for test pypi.