### PR TITLE
Fix tensorboard docker imagee

### DIFF
--- a/flambe/cluster/const.py
+++ b/flambe/cluster/const.py
@@ -5,7 +5,7 @@ SOCKET_TIMEOUT = 50
 RETRY_DELAY = 1
 RETRIES = 60
 
-TENSORBOARD_IMAGE = "tensorflow/tensorflow:latest"
+TENSORBOARD_IMAGE = "tensorflow/tensorflow:1.15.0"
 
 RAY_REDIS_PORT = 12345
 


### PR DESCRIPTION
Fix `1.15.0` as our tensorflow docker image for serving tensorboard in the cluster. 