### PR TITLE
New resources mechanism

### DIFF
--- a/docs/understanding/experiments.rst
+++ b/docs/understanding/experiments.rst
@@ -261,9 +261,9 @@ In case a resource is a remote URL, then flambé will download the file fow you 
 **Resources in remote experiment**
 
 When running remote experiments, all resources will be rsynced into the instances so that they are available in
-the cluster **unless a ``!cluster`` tag is specified**.
+the cluster **unless a ``!remote`` tag is specified**.
 
-The ``!cluster`` tag is useful when the cluster needs to handle the resources. The local process will just
+The ``!remote`` tag is useful when the cluster needs to handle the resources. The local process will just
 ignore those tagged resources.
 
 For example:
@@ -274,14 +274,14 @@ For example:
     ...
 
     resources:
-        data: !cluster path/to/train.csv  # This file is already in all instances of the cluster
+        data: !remote path/to/train.csv  # This file is already in all instances of the cluster
     ...
  
 When running this example in a cluster, then no ``rsync`` will be involved as flambé assumes the resource
 path ``path/to/train.csv`` exists in all instances of the cluster.
 
 .. tip::
-    You can also specify remote URL with the ``!cluster`` tag:
+    You can also specify remote URL with the ``!remote`` tag:
 
     .. code-block:: yaml
 
@@ -289,14 +289,14 @@ path ``path/to/train.csv`` exists in all instances of the cluster.
         ...
 
         resources:
-            data: !cluster s3://bucket/data.csv
+            data: !remote s3://bucket/data.csv
         ...
 
     In this case the cluster will download the data instead of the local process (if it has permissions to
     do so)
 
 
-.. attention:: The ``!cluster`` tag is only useful in remote experiments. If the user is running local experiments, using ``!cluster`` will fail.
+.. attention:: The ``!remote`` tag is only useful in remote experiments. If the user is running local experiments, using ``!remote`` will fail.
 
 .. _understanding-experiments-scheduling_label:
 

--- a/docs/understanding/experiments.rst
+++ b/docs/understanding/experiments.rst
@@ -261,9 +261,9 @@ In case a resource is a remote URL, then flambé will download the file fow you 
 **Resources in remote experiment**
 
 When running remote experiments, all resources will be rsynced into the instances so that they are available in
-the cluster **unless a ``!remote`` tag is specified**.
+the cluster **unless a ``!cluster`` tag is specified**.
 
-The ``!remote`` tag is useful when the cluster needs to handle the resources. The local process will just
+The ``!cluster`` tag is useful when the cluster needs to handle the resources. The local process will just
 ignore those tagged resources.
 
 For example:
@@ -274,14 +274,14 @@ For example:
     ...
 
     resources:
-        data: !remote path/to/train.csv  # This file is already in all instances of the cluster
+        data: !cluster path/to/train.csv  # This file is already in all instances of the cluster
     ...
  
 When running this example in a cluster, then no ``rsync`` will be involved as flambé assumes the resource
 path ``path/to/train.csv`` exists in all instances of the cluster.
 
 .. tip::
-    You can also specify remote URL with the ``!remote`` tag:
+    You can also specify remote URL with the ``!cluster`` tag:
 
     .. code-block:: yaml
 
@@ -289,14 +289,14 @@ path ``path/to/train.csv`` exists in all instances of the cluster.
         ...
 
         resources:
-            data: !remote s3://bucket/data.csv
+            data: !cluster s3://bucket/data.csv
         ...
 
     In this case the cluster will download the data instead of the local process (if it has permissions to
     do so)
 
 
-.. attention:: The ``!remote`` tag is only useful in remote experiments. If the user is running local experiments, using ``!remote`` will fail.
+.. attention:: The ``!cluster`` tag is only useful in remote experiments. If the user is running local experiments, using ``!cluster`` will fail.
 
 .. _understanding-experiments-scheduling_label:
 

--- a/docs/understanding/experiments.rst
+++ b/docs/understanding/experiments.rst
@@ -225,12 +225,8 @@ Resources (Additional Files and Folders)
 
 The :attr:`~flambe.experiment.Experiment.resources` argument lets users specify files that can be used in the
 :class:`~flambe.experiment.Experiment` (usually local datasets, embeddings or other files).
-In this section, you can put your resources under ``local`` or ``remote``.
 
-**Local resources**: The ``local`` section must include all local files.
-
-**Remote resources**: The ``remote`` section must contain all files that are going to be located in the
-instances and must not be uploaded. This feature is only useful when running remotely (read :ref:`understanding-clusters_label`)
+For example:
 
 .. code-block:: yaml
 
@@ -238,14 +234,13 @@ instances and must not be uploaded. This feature is only useful when running rem
     ...
 
     resources:
-        local:
-            data: path/to/train.csv
-            embeddings: path/to/embeddings.txt
-        remote:
-            remote_embeddings: /file/in/instance/
-        ...
+        data: path/to/train.csv
+        embeddings: s3://mybucket/embeddings.bin
+    ...
 
-.. attention:: The ``remote`` section is only useful in remote experiments. If the user is running local experiments, then only the ``local`` section should be used.
+In case a resource is a remote URL, then flambé will download the file fow you (relying on the user local permissions)
+
+.. attention:: Currently S3 and HTTP hosted resources are supported.
 
 ``resources`` can be referenced in the pipeline via linking:
 
@@ -256,12 +251,52 @@ instances and must not be uploaded. This feature is only useful when running rem
 
     resources:
         ...
-        local:
-            embeddings: path/to/embeddings.txt
+        embeddings: path/to/embeddings.txt
 
     pipeline:
         ...
           some_field: !@ embeddings
+
+
+**Resources in remote experiment**
+
+When running remote experiments, all resources will be rsynced into the instances so that they are available in
+the cluster **unless a ``!cluster`` tag is specified**.
+
+The ``!cluster`` tag is useful when the cluster needs to handle the resources. The local process will just
+ignore those tagged resources.
+
+For example:
+
+.. code-block:: yaml
+
+    !Experiment
+    ...
+
+    resources:
+        data: !cluster path/to/train.csv  # This file is already in all instances of the cluster
+    ...
+ 
+When running this example in a cluster, then no ``rsync`` will be involved as flambé assumes the resource
+path ``path/to/train.csv`` exists in all instances of the cluster.
+
+.. tip::
+    You can also specify remote URL with the ``!cluster`` tag:
+
+    .. code-block:: yaml
+
+        !Experiment
+        ...
+
+        resources:
+            data: !cluster s3://bucket/data.csv
+        ...
+
+    In this case the cluster will download the data instead of the local process (if it has permissions to
+    do so)
+
+
+.. attention:: The ``!cluster`` tag is only useful in remote experiments. If the user is running local experiments, using ``!cluster`` will fail.
 
 .. _understanding-experiments-scheduling_label:
 

--- a/flambe/compile/downloader.py
+++ b/flambe/compile/downloader.py
@@ -143,7 +143,7 @@ def download_s3_folder(url: str, destination: str) -> None:
 
 
 @contextmanager
-def download_manager(path: str):
+def download_manager(path: str, folder: str = None):
     """Manager for downloading remote URLs
 
     Parameters
@@ -152,6 +152,8 @@ def download_manager(path: str):
         The remote URL to download. Currently, only S3 and http/https
         URLs are supported.
         In case it's already a local path, it yields the same path.
+    folder: str
+        Optional folder where all remote content will be downloaded.
 
     Examples
     --------
@@ -168,6 +170,10 @@ def download_manager(path: str):
     """
     url = urlparse(path)
 
+    if not folder:
+        tmp_dir = tempfile.TemporaryDirectory()
+        folder = tmp_dir.name
+
     if not url.scheme:
         # 'path' is a local path
         if os.path.exists(os.path.expanduser(path)):
@@ -176,27 +182,28 @@ def download_manager(path: str):
             raise ValueError(f"Path: '{path}' does not exist locally.")
 
     else:
+        trailing_url = url.path[:-1] if url.path.endswith('/') else url.path
+        fname = trailing_url[trailing_url.rfind('/') + 1:]
+        destination = os.path.join(folder, fname)
+
         # 'path' is a remote URL
         if url.scheme == 's3':
             if not s3_exists(url):
                 raise ValueError(f"S3 url: '{path}' is not available")
 
             if s3_remote_file(url):
-                with tempfile.NamedTemporaryFile() as tmpfile:
-                    download_s3_file(path, tmpfile.name)
-                    yield tmpfile.name
+                download_s3_file(path, destination)
             else:
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    download_s3_folder(path, tmpdir)
-                    yield tmpdir
+                download_s3_folder(path, destination)
+
+            yield destination
 
         elif url.scheme == 'http' or url.scheme == 'https':
             if not http_exists(path):
                 raise ValueError(f"HTTP url: '{path}' is not available")
 
-            with tempfile.NamedTemporaryFile('wb') as tmpfile:
-                download_http_file(path, tmpfile.name)
-                yield tmpfile.name
+            download_http_file(path, destination)
+            yield destination
 
         else:
             raise ValueError(

--- a/flambe/compile/downloader.py
+++ b/flambe/compile/downloader.py
@@ -170,6 +170,7 @@ def download_manager(path: str, folder: str = None):
     """
     url = urlparse(path)
 
+    tmp_dir = None
     if not folder:
         tmp_dir = tempfile.TemporaryDirectory()
         folder = tmp_dir.name
@@ -209,3 +210,6 @@ def download_manager(path: str, folder: str = None):
             raise ValueError(
                 f"'{path}' is not a valid remote URL. Only S3 and http/https URLs are supported."
             )
+
+    if tmp_dir:
+        tmp_dir.cleanup()

--- a/flambe/experiment/experiment.py
+++ b/flambe/experiment/experiment.py
@@ -158,7 +158,7 @@ class Experiment(ClusterRunnable):
         resources: Dict[str, Union[str, RemoteResource]],
         folder: str = None
     ) -> Dict[str, Union[str, RemoteResource]]:
-        """Download resources that are not tagged with '!cluster'
+        """Download resources that are not tagged with '!remote'
         into a given directory.
 
         Parameters
@@ -174,7 +174,7 @@ class Experiment(ClusterRunnable):
         -------
         Dict[str, Union[str, RemoteResource]]
             The resources dict where the remote urls that
-            don't contain '!cluster' point now to the local
+            don't contain '!remote' point now to the local
             path where the resource was downloaded.
 
         """
@@ -228,8 +228,8 @@ class Experiment(ClusterRunnable):
 
         if any(map(lambda x: isinstance(x, RemoteResource), self.resources.values())):
             raise ValueError(
-                f"Local experiments doesn't support resources with '!cluster' tags. " +
-                "The '!cluster' tag is used for those resources that need to be handled " +
+                f"Local experiments doesn't support resources with '!remote' tags. " +
+                "The '!remote' tag is used for those resources that need to be handled " +
                 "in the cluster when running remote experiments.")
 
         if not self.env:

--- a/flambe/experiment/experiment.py
+++ b/flambe/experiment/experiment.py
@@ -157,6 +157,24 @@ class Experiment(ClusterRunnable):
         self,
         resources: Dict[str, Union[str, RemoteResource]]
     ) -> Dict[str, Union[str, RemoteResource]]:
+        """Download resources that are not tagged with '!cluster'
+        into a temporary directory that is kept until Experiment
+        is done running.
+
+        Parameters
+        ----------
+        resources: Dict[str, Union[str, RemoteResource]]
+            The resources dict
+
+        Returns
+        -------
+        Dict[str, Union[str, RemoteResource]]
+            The resources dict where the remote urls that
+            don't contain '!cluster' point now to the local
+            path where the resource was downloaded.
+
+        """
+        # Keep the resources temporary dict for later
         self.tmp_resources_dir = tempfile.TemporaryDirectory()
         ret = {}
         for k, v in resources.items():

--- a/flambe/experiment/experiment.py
+++ b/flambe/experiment/experiment.py
@@ -3,9 +3,10 @@ import os
 import re
 import logging
 from copy import deepcopy
-from typing import Dict, Optional, Any, Union, Sequence
+from typing import Dict, Optional, Union, Sequence
 from collections import OrderedDict
 import shutil
+import tempfile
 
 from tqdm import tqdm
 import ray
@@ -14,12 +15,13 @@ from ray.tune.schedulers import TrialScheduler
 from ray.tune.logger import DEFAULT_LOGGERS, TFLogger
 
 from flambe.compile import Schema, Component
-from flambe.compile.utils import _is_url
 from flambe.runnable import ClusterRunnable
+from flambe.compile.downloader import download_manager
 from flambe.cluster import errors as man_errors
 from flambe.cluster import const
 from flambe.cluster import Cluster
 from flambe.experiment import utils, wording
+from flambe.experiment.options import RemoteResource
 from flambe.runnable import RemoteEnvironment
 from flambe.runnable import error
 from flambe.runnable import utils as run_utils
@@ -96,7 +98,7 @@ class Experiment(ClusterRunnable):
                  debug: bool = False,
                  devices: Dict[str, int] = None,
                  save_path: Optional[str] = None,
-                 resources: Optional[Dict[str, Dict[str, Any]]] = None,
+                 resources: Optional[Dict[str, Union[str, RemoteResource]]] = None,
                  search: OptionalSearchAlgorithms = None,
                  schedulers: OptionalTrialSchedulers = None,
                  reduce: Optional[Dict[str, int]] = None,
@@ -130,6 +132,7 @@ class Experiment(ClusterRunnable):
         self.resume = resume
         self.debug = debug
         self.devices = devices
+        self.resources = resources or dict()
         self.pipeline = pipeline
         # Compile search algorithms if needed
         self.search = search or dict()
@@ -142,7 +145,6 @@ class Experiment(ClusterRunnable):
             if isinstance(scheduler, Schema):
                 self.schedulers[stage_name] = scheduler()
         self.reduce = reduce or dict()
-        self.resources = resources or dict()
         self.max_failures = max_failures
         self.stop_on_failure = stop_on_failure
         self.merge_plot = merge_plot
@@ -150,6 +152,21 @@ class Experiment(ClusterRunnable):
             raise TypeError("Pipeline argument is not of type Dict[str, Schema]. "
                             f"Got {type(pipeline).__name__} instead")
         self.pipeline = pipeline
+
+    def process_resources(
+        self,
+        resources: Dict[str, Union[str, RemoteResource]]
+    ) -> Dict[str, Union[str, RemoteResource]]:
+        self.tmp_resources_dir = tempfile.TemporaryDirectory()
+        ret = {}
+        for k, v in resources.items():
+            if not isinstance(v, RemoteResource):
+                with download_manager(v, self.tmp_resources_dir.name) as path:
+                    ret[k] = path
+            else:
+                ret[k] = v
+
+        return ret
 
     def run(self, force: bool = False, verbose: bool = False, **kwargs):
         """Run an Experiment"""
@@ -187,14 +204,17 @@ class Experiment(ClusterRunnable):
                 os.makedirs(full_save_path)
                 logger.debug(f"{full_save_path} created to store output")
 
-        local_vars = self.resources.get('local', {}) or {}
-        local_vars = utils.rel_to_abs_paths(local_vars)
-        remote_vars = self.resources.get('remote', {}) or {}
+        if any(map(lambda x: isinstance(x, RemoteResource), self.resources.values())):
+            raise ValueError(
+                f"Local experiments doesn't support resources with '!cluster' tags. " +
+                "The '!cluster' tag is used for those resources that need to be handled " +
+                "in the cluster when running remote experiments.")
 
-        global_vars = dict(local_vars, **remote_vars)
+        # This will download remote resources.
+        resources = self.process_resources(self.resources)
 
         # Check that links are in order (i.e topologically in pipeline)
-        utils.check_links(self.pipeline, global_vars)
+        utils.check_links(self.pipeline, resources)
 
         # Check that only computable blocks are given
         # search algorithms and schedulers
@@ -265,7 +285,7 @@ class Experiment(ClusterRunnable):
         schemas_dag: OrderedDict = OrderedDict()
         for block_id, schema_block in self.pipeline.items():
             schemas_dag[block_id] = schema_block
-            relevant_ids = utils.extract_needed_blocks(schemas_dag, block_id, global_vars)
+            relevant_ids = utils.extract_needed_blocks(schemas_dag, block_id, resources)
             dependencies = deepcopy(relevant_ids)
             dependencies.discard(block_id)
 
@@ -288,7 +308,7 @@ class Experiment(ClusterRunnable):
             success[block_id] = True
 
             self.progress_state.checkpoint_start(block_id)
-            relevant_ids = utils.extract_needed_blocks(schemas, block_id, global_vars)
+            relevant_ids = utils.extract_needed_blocks(schemas, block_id, resources)
             relevant_schemas = {k: v for k, v in deepcopy(schemas).items() if k in relevant_ids}
 
             # Set resume
@@ -314,7 +334,7 @@ class Experiment(ClusterRunnable):
                               'schemas': Schema.serialize(schemas_dict),
                               'checkpoints': checkpoints,
                               'to_run': block_id,
-                              'global_vars': global_vars,
+                              'global_vars': resources,
                               'verbose': verbose,
                               'custom_modules': list(self.extensions.keys()),
                               'debug': self.debug}
@@ -429,6 +449,9 @@ class Experiment(ClusterRunnable):
 
         self.progress_state.finish()
 
+        if hasattr(self, 'tmp_resources_dir'):
+            self.tmp_resources_dir.cleanup()
+
     def setup(self, cluster: Cluster, extensions: Dict[str, str], force: bool, **kwargs) -> None:
         """Prepare the cluster for the Experiment remote execution.
 
@@ -500,16 +523,23 @@ class Experiment(ClusterRunnable):
         if not cluster.check_ray_cluster():
             raise man_errors.ClusterError("Ray cluster not launched correctly.")
 
-        local_resources = self.resources.get("local")
-        new_resources = {"remote": self.resources.get("remote", dict())}
+        local_resources = {k: v for k, v in self.resources.items()
+                           if not isinstance(v, RemoteResource)}
+        # This will download remote resources.
+        local_resources = self.process_resources(local_resources)
+
         if local_resources:
-            new_resources['local'] = cluster.send_local_content(
+            new_resources = cluster.send_local_content(
                 local_resources,
                 os.path.join(cluster.orchestrator.get_home_path(), self.name, "resources"),
                 all_hosts=True
             )
         else:
-            new_resources['local'] = dict()
+            new_resources = dict()
+
+        # Add the cluster resources without the tag
+        new_resources.update({k: v.location for k, v in self.resources.items()
+                              if isinstance(v, RemoteResource)})
 
         if cluster.orchestrator.is_tensorboard_running():
             if force:
@@ -564,19 +594,3 @@ class Experiment(ClusterRunnable):
                     "Experiment name should contain only alphanumeric characters " +
                     "(with optional - or _ in between)"
                 )
-
-        # Check if resources contains only local and remote
-        if self.resources:
-            if len(list(filter(lambda x: x not in ['local', 'remote'],
-                               self.resources.keys()))) > 0:
-                raise error.ParsingRunnableError(
-                    f"'resources' section must contain only 'local' section and/or 'remote' keys"
-                )
-
-        # Check if local resources exists:
-        if self.resources and self.resources.get("local"):
-            for v in self.resources["local"].values():
-                if not _is_url(v) and not os.path.exists(os.path.expanduser(v)):
-                    raise error.ParsingRunnableError(
-                        f"Local resource '{v}' does not exist."
-                    )

--- a/flambe/experiment/experiment.py
+++ b/flambe/experiment/experiment.py
@@ -3,7 +3,7 @@ import os
 import re
 import logging
 from copy import deepcopy
-from typing import Dict, Optional, Union, Sequence
+from typing import Dict, Optional, Union, Sequence, cast
 from collections import OrderedDict
 import shutil
 import tempfile
@@ -543,8 +543,11 @@ class Experiment(ClusterRunnable):
 
         local_resources = {k: v for k, v in self.resources.items()
                            if not isinstance(v, RemoteResource)}
+
         # This will download remote resources.
-        local_resources = self.process_resources(local_resources)
+        local_resources = self.process_resources(local_resources)  # type: ignore
+
+        local_resources = cast(Dict[str, str], local_resources)
 
         if local_resources:
             new_resources = cluster.send_local_content(

--- a/flambe/experiment/options.py
+++ b/flambe/experiment/options.py
@@ -133,7 +133,7 @@ class SampledUniformSearchOptions(Sequence[Number], Options):
         return representer.represent_sequence('!g', node.elements)
 
 
-@alias('cluster')
+@alias('remote')
 class RemoteResource(Registrable):
 
     def __init__(self, location: str) -> None:

--- a/flambe/experiment/options.py
+++ b/flambe/experiment/options.py
@@ -141,8 +141,9 @@ class RemoteResource(Registrable):
 
     @classmethod
     def to_yaml(cls, representer: Any, node: Any, tag: str) -> Any:
-        # NOTE: here we are using scalar even considering this is a string.
-        # Other representers are not able to represent correctly this information
+        # NOTE: here we are using scalar even considering this
+        # is a string. Other representers are not able to representer
+        # correctly this information
         return representer.represent_scalar(tag, node.location)
 
     @classmethod

--- a/flambe/experiment/options.py
+++ b/flambe/experiment/options.py
@@ -133,8 +133,8 @@ class SampledUniformSearchOptions(Sequence[Number], Options):
         return representer.represent_sequence('!g', node.elements)
 
 
-@alias('remote')
-class RemoteResource(Registrable):
+@alias('cluster')
+class ClusterResource(Registrable):
 
     def __init__(self, location: str) -> None:
         self.location = location
@@ -147,6 +147,6 @@ class RemoteResource(Registrable):
         return representer.represent_scalar(tag, node.location)
 
     @classmethod
-    def from_yaml(cls, constructor: Any, node: Any, factory_name: str) -> 'RemoteResource':
+    def from_yaml(cls, constructor: Any, node: Any, factory_name: str) -> 'ClusterResource':
         value = constructor.construct_yaml_str(node)
         return cls(location=value)

--- a/flambe/experiment/options.py
+++ b/flambe/experiment/options.py
@@ -131,3 +131,21 @@ class SampledUniformSearchOptions(Sequence[Number], Options):
     @classmethod
     def to_yaml(cls, representer: Any, node: Any, tag: str) -> Any:
         return representer.represent_sequence('!g', node.elements)
+
+
+@alias('cluster')
+class RemoteResource(Registrable):
+
+    def __init__(self, location: str) -> None:
+        self.location = location
+
+    @classmethod
+    def to_yaml(cls, representer: Any, node: Any, tag: str) -> Any:
+        # NOTE: here we are using scalar even considering this is a string.
+        # Other representers are not able to represent correctly this information
+        return representer.represent_scalar(tag, node.location)
+
+    @classmethod
+    def from_yaml(cls, constructor: Any, node: Any, factory_name: str) -> 'RemoteResource':
+        value = constructor.construct_yaml_str(node)
+        return cls(location=value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ awscli==1.16.202
 pytorch-transformers==1.1.0
 jinja2~=2.10.1
 fastBPE==0.1.0
+ninja~=1.9.0

--- a/tests/integration/test_resources_experiment.py
+++ b/tests/integration/test_resources_experiment.py
@@ -1,0 +1,32 @@
+import pytest
+import tempfile
+import subprocess
+import os
+
+
+@pytest.mark.integration
+def test_resources_config():
+    config = """
+!Experiment
+
+name: random
+save_path: {}
+
+resources:
+  train: {}
+
+pipeline:
+  dataset: !TabularDataset.from_path
+    train_path: !@ train
+
+"""
+
+    with tempfile.TemporaryDirectory() as d, tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+        test_data_folder = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'data')
+        train_data = os.path.join(test_data_folder, 'dummy_tabular', 'train.csv')
+
+        exp = config.format(d, train_data)
+        f.write(exp)
+        f.flush()
+        ret = subprocess.run(['flambe', f.name])
+        assert ret.returncode == 0

--- a/tests/unit/compile/test_downloader.py
+++ b/tests/unit/compile/test_downloader.py
@@ -4,7 +4,6 @@ import pytest
 import mock
 import os
 import boto3
-import subprocess
 import responses
 import tempfile
 

--- a/tests/unit/compile/test_downloader.py
+++ b/tests/unit/compile/test_downloader.py
@@ -73,22 +73,26 @@ def test_s3_file_given_folder(mock_check_output):
     s3.put_object(Bucket='mybucket', Key="some_file.txt", Body="CONTENT")
 
     with tempfile.TemporaryDirectory() as t:
-        with downloader.download_manager("s3://mybucket/some_file.txt", t) as p:
-            assert p == os.path.join(t, "some_file.txt")
+        destination = os.path.join(t, "some_file.txt")
+        with downloader.download_manager("s3://mybucket/some_file.txt", destination) as p:
+            assert p == destination
 
     s3.put_object(Bucket='mybucket', Key="some_folder/some_other_file.txt", Body="CONTENT")
 
     with tempfile.TemporaryDirectory() as t:
-        with downloader.download_manager("s3://mybucket/some_folder/some_other_file.txt", t) as p:
-            assert p == os.path.join(t, "some_other_file.txt")
+        destination = os.path.join(t, "some_other_file.txt")
+        with downloader.download_manager("s3://mybucket/some_folder/some_other_file.txt", destination) as p:
+            assert p == destination
 
     with tempfile.TemporaryDirectory() as t:
-        with downloader.download_manager("s3://mybucket/some_folder", t) as p:
-            assert p == os.path.join(t, "some_folder")
+        destination = os.path.join(t, "some_folder")
+        with downloader.download_manager("s3://mybucket/some_folder", destination) as p:
+            assert p == destination
 
     with tempfile.TemporaryDirectory() as t:
-        with downloader.download_manager("s3://mybucket/some_folder/", t) as p:
-            assert p == os.path.join(t, "some_folder")
+        destination = os.path.join(t, "some_folder")
+        with downloader.download_manager("s3://mybucket/some_folder/", destination) as p:
+            assert p == destination
 
 
 def test_invalid_local_file():

--- a/tests/unit/experiment/test_experiment_preprocess.py
+++ b/tests/unit/experiment/test_experiment_preprocess.py
@@ -129,47 +129,6 @@ pipeline:
         runnable.parse()
 
 
-def test_preprocessor_invalid_resources(context):
-    config = """
-!Experiment
-
-name: random-name
-
-resources:
-  random:
-    r0: /non/path
-
-pipeline:
-    mod: !Module
-"""
-    with pytest.raises(error.ParsingRunnableError):
-        ex = context(config)
-        content, ext = ex.first_parse()
-        runnable = ex.compile_runnable(content)
-        runnable.parse()
-
-
-def test_preprocessor_invalid_resources2(context):
-    config = """
-!Experiment
-
-name: random-name
-
-resources:
-  remote:
-    r0: /non/path
-  random:
-    r0: /non/path
-
-pipeline:
-    mod: !Module
-"""
-    with pytest.raises(error.ParsingRunnableError):
-        ex = context(config)
-        content, ext = ex.first_parse()
-        runnable = ex.compile_runnable(content)
-        runnable.parse()
-
 
 def test_preprocessor_valid_resources(context):
     config = """
@@ -178,8 +137,7 @@ def test_preprocessor_valid_resources(context):
 name: random-name
 
 resources:
-  remote:
-    r0: /remote/path
+  r0: !cluster /remote/path
 
 pipeline:
     mod: !Module
@@ -188,49 +146,6 @@ pipeline:
     content, ext = ex.first_parse()
     runnable = ex.compile_runnable(content)
     runnable.parse()
-
-
-def test_preprocessor_invalid_resources4(context):
-    config = """
-!Experiment
-
-name: random-name
-
-resources:
-  remote:
-    r0: /remote/path
-  local:
-    r1: /non/path
-
-pipeline:
-    mod: !Module
-"""
-    with pytest.raises(error.ParsingRunnableError):
-        ex = context(config)
-        content, ext = ex.first_parse()
-        runnable = ex.compile_runnable(content)
-        runnable.parse()
-
-
-def test_preprocessor_invalid_resources5(context):
-    config = """
-!Experiment
-
-name: random-name
-
-resources:
-  remote:
-  local:
-    r1: /non/path
-
-pipeline:
-    mod: !Module
-"""
-    with pytest.raises(error.ParsingRunnableError):
-        ex = context(config)
-        content, ext = ex.first_parse()
-        runnable = ex.compile_runnable(content)
-        runnable.parse()
 
 
 def test_preprocessor_valid_paths(context):
@@ -248,25 +163,6 @@ pipeline:
     content, ext = ex.first_parse()
     runnable = ex.compile_runnable(content)
     runnable.parse()
-
-
-def test_preprocessor_inexistent_paths(context):
-    config = """
-!Experiment
-
-name: random-name
-
-resources:
-  v1: non/existent/path
-
-pipeline:
-    mod: !Module
-"""
-    with pytest.raises(error.ParsingRunnableError):
-        ex = context(config)
-        content, ext = ex.first_parse()
-        runnable = ex.compile_runnable(content)
-        runnable.parse()
 
 
 def test_preprocessor_extensions_non_package(context):

--- a/tests/unit/experiment/test_experiment_preprocess.py
+++ b/tests/unit/experiment/test_experiment_preprocess.py
@@ -137,7 +137,7 @@ def test_preprocessor_valid_resources(context):
 name: random-name
 
 resources:
-  r0: !cluster /remote/path
+  r0: !remote /remote/path
 
 pipeline:
     mod: !Module

--- a/tests/unit/experiment/test_experiment_preprocess.py
+++ b/tests/unit/experiment/test_experiment_preprocess.py
@@ -137,7 +137,7 @@ def test_preprocessor_valid_resources(context):
 name: random-name
 
 resources:
-  r0: !remote /remote/path
+  r0: !cluster /remote/path
 
 pipeline:
     mod: !Module


### PR DESCRIPTION
Resource are not anymore:
```
resources:
  local:
    emb: /path/to/local/embeddings
  remote:
    other_emb: /path/to/embedding/in/cluster
```

Instead:

```
resources:
    emb: /path/to/local/embeddings
    other_emb: !cluster /path/to/embedding/in/cluster
```

And even more!:

```
resources:
    emb: s3://bucket/embeddings
    other_emb: !cluster s3://bucket/embeddings
```

Using `!cluster` with remote URLs will leave the cluster to do the download.