### PR TITLE
Issue 135 safer load

### DIFF
--- a/flambe/compile/serialization.py
+++ b/flambe/compile/serialization.py
@@ -219,9 +219,12 @@ def save_state_to_file(state: State,
         some files.
 
     """
-    if os.path.exists(path) and os.path.isdir(path) and len(os.listdir(path)) == 0:
-        raise ValueError('The given path points to an existing directory containing files. '
-                         'Please use a new path, or an existing directory without files.')
+    if os.path.exists(path) and os.path.isdir(path):
+        dir_contents = os.listdir(path)
+        if len(dir_contents) != 0:
+            raise ValueError('The given path points to an existing directory containing files:\n'
+                             f'{dir_contents}\n'
+                             'Please use a new path, or an existing directory without files.')
     if compress:
         original_path = path
         temp = tempfile.TemporaryDirectory()

--- a/flambe/compile/serialization.py
+++ b/flambe/compile/serialization.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 from typing import Dict, Any, Iterable, Tuple, Optional, Sequence, NamedTuple, List, Mapping
 import tarfile
 import tempfile
-import shutil
 
 import dill
 import torch


### PR DESCRIPTION
This PR removes the behavior where flambe's `load` and `save` functions would use the current working directory for temporary files (mainly when working with compressed archives) and manually handle cleanup. We now use more standard and safe Python built-ins for working with temporary directories via `tempfile`