### PR TITLE
add scripts to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include requirements.txt
 include tests/requirements.txt
 include flambe/experiment/webapp/templates/*
 include flambe/experiment/webapp/static/*
+include flambe/cluster/instance/scripts/*


### PR DESCRIPTION
The scripts should be included in the packaged, as they are called in the SSHCluster.