### PR TITLE
remove accidental lines of code

### DIFF
--- a/flambe/field/text.py
+++ b/flambe/field/text.py
@@ -146,8 +146,6 @@ class TextField(Field):
                                                           binary=self.embeddings_binary)
             elif self.embeddings_format == 'fasttext':
                 model = fasttext.load_facebook_vectors(self.embeddings)
-                model = KeyedVectors.load_fasttext_format(self.embeddings,
-                                                          binary=self.embeddings_binary)
             elif self.embeddings_format == 'gensim':
                 try:
                     model = KeyedVectors.load(self.embeddings)


### PR DESCRIPTION
There was an extra line of commented code included at some point, this removes that code and fixes our `TextField`.