### PR TITLE
Update script.rst docs to include experiment name

### DIFF
--- a/docs/tutorials/script.rst
+++ b/docs/tutorials/script.rst
@@ -70,6 +70,8 @@ Once you have done the above step, you can use your script in Flambé as follows
     ---
 
     !Experiment
+    
+    name: example
 
     pipeline:
       stage_0: !Script


### PR DESCRIPTION
Adds `name` parameter to the script mode example in [these docs](http://flambe.ai/en/latest/tutorials/script.html) to prevent this error:

```
flambe.runnable.error.ParsingRunnableError: Syntax error compiling the runnable: __init__() missing 1 required positional argument: 'name'
```