### PR TITLE
update ray to version that works with mac os

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ tqdm~=4.28
 scikit-learn~=0.20.3
 paramiko==2.4.2
 boto3>=1.9.100,<=1.9.172
-ray==0.7.2
+ray==0.7.6
 requests~=2.21.0
 Flask~=1.0.0
 tensorboardx-hparams==1.7.2


### PR DESCRIPTION
I'm getting this error when I have ray==0.7.2 installed on my mac: 
```
E   ImportError: dlopen(/Users/cdfox/work/prodml/.mleng_pve/lib/python3.6/site-packages/ray/pyarrow_files/pyarrow/lib.cpython-36m-darwin.so, 2): Library not loaded: /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib
E     Referenced from: /Users/cdfox/work/prodml/.mleng_pve/lib/python3.6/site-packages/ray/pyarrow_files/pyarrow/libarrow.14.dylib
E     Reason: image not found
```

I believe Melanie and others have seen the same error. The fix seems to be updating ray.