### PR TITLE
Adding tests for python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,9 @@
+python3: &python3
+    command: |
+        apt-get update
+        apt-get install -y python3-dev
+
+
 version: 2
 jobs:
   unit_tests:
@@ -11,9 +17,7 @@ jobs:
               - flambe-cache-{{ .Branch }}
               - flambe-cache-
         - run:
-            command: |
-                apt-get update
-                apt-get install -y python3-dev
+            <<: *python3
         - run: python3 -m pip install --user tox awscli
         - run: python3 -m awscli configure set region us-east-1
         - run:
@@ -33,9 +37,7 @@ jobs:
       steps:
         - checkout
         - run:
-            command: |
-                apt-get update
-                apt-get install -y python3-dev
+            <<: *python3
         - run: python3 -m pip install --user tox awscli
         - run: python3 -m awscli configure set region us-east-1
         - run:
@@ -55,9 +57,7 @@ jobs:
       steps:
         - checkout
         - run:
-            command: |
-                apt-get update
-                apt-get install -y python3-dev
+            <<: *python3
         - run: python3 -m pip install --user tox awscli
         - run: python3 -m awscli configure set region us-east-1
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-python3: &python3
+python37setup: &python37setup
     command: |
         apt-get update
         apt-get install -y python3-dev
@@ -17,7 +17,7 @@ jobs:
               - flambe-cache-{{ .Branch }}
               - flambe-cache-
         - run:
-            <<: *python3
+            <<: *python37setup
         - run: python3 -m pip install --user tox awscli
         - run: python3 -m awscli configure set region us-east-1
         - run:
@@ -37,7 +37,7 @@ jobs:
       steps:
         - checkout
         - run:
-            <<: *python3
+            <<: *python37setup
         - run: python3 -m pip install --user tox awscli
         - run: python3 -m awscli configure set region us-east-1
         - run:
@@ -57,7 +57,7 @@ jobs:
       steps:
         - checkout
         - run:
-            <<: *python3
+            <<: *python37setup
         - run: python3 -m pip install --user tox awscli
         - run: python3 -m awscli configure set region us-east-1
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,10 @@ jobs:
               # when lock file changes, use increasingly general patterns to restore cache
               - flambe-cache-{{ .Branch }}
               - flambe-cache-
+        - run:
+            command: |
+                apt-get update
+                apt-get install -y python3-dev
         - run: python3 -m pip install --user tox awscli
         - run: python3 -m awscli configure set region us-east-1
         - run:
@@ -28,6 +32,10 @@ jobs:
         - image: python:3.6
       steps:
         - checkout
+        - run:
+            command: |
+                apt-get update
+                apt-get install -y python3-dev
         - run: python3 -m pip install --user tox awscli
         - run: python3 -m awscli configure set region us-east-1
         - run:
@@ -46,6 +54,10 @@ jobs:
         - image: python:3.6
       steps:
         - checkout
+        - run:
+            command: |
+                apt-get update
+                apt-get install -y python3-dev
         - run: python3 -m pip install --user tox awscli
         - run: python3 -m awscli configure set region us-east-1
         - run:

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@
 # requirements will not be installed in the [deps] section
 
 [tox]
-envlist = py36
+envlist = py36, py37
 
 [testenv]
 passenv = *


### PR DESCRIPTION
- `tox` now must execute test suite in `3.7`
- CCI was fixed so that it can install requirements in `3.7`

**The python:3.6 image we are using already contains both python 3.6 and python 3.7**