### PR TITLE
add post init hooks to link and fix trainer precompile

### DIFF
--- a/flambe/compile/component.py
+++ b/flambe/compile/component.py
@@ -594,6 +594,7 @@ class Link(Registrable):
         self.target_leaf: Optional[Schema] = None
         self.local = local
         self.resolved: Optional[Any] = None
+        self.post_init_hooks: Sequence[Callable] = []
 
     @property
     def root_schema(self) -> str:
@@ -642,6 +643,8 @@ class Link(Registrable):
             for attr in self.attr_path:
                 current_obj = getattr(current_obj, attr)
         self.resolved = current_obj
+        for hook in self.post_init_hooks:
+            hook(current_obj)
         return current_obj
 
     @classmethod

--- a/flambe/learn/train.py
+++ b/flambe/learn/train.py
@@ -7,7 +7,7 @@ from torch.optim.lr_scheduler import _LRScheduler, ReduceLROnPlateau
 from torch.nn.utils.clip_grad import clip_grad_norm_, clip_grad_value_
 
 from flambe.dataset import Dataset
-from flambe.compile import Schema, State, Component
+from flambe.compile import Schema, State, Component, Link
 from flambe.learn.utils import select_device
 from flambe.nn import Module
 from flambe.sampler import Sampler
@@ -369,5 +369,5 @@ class Trainer(Component):
 
         # Compile all objects and push Modules to the device
         for k, obj in kwargs.items():
-            if isinstance(obj, Schema):
+            if isinstance(obj, (Schema, Link)):
                 obj.post_init_hooks.append(move_to_device)


### PR DESCRIPTION
This should fix the issue we observed with the models not being moved to GPU when they were linked to.