### PR TITLE
load TabularDataset with smart_open

### DIFF
--- a/flambe/dataset/tabular.py
+++ b/flambe/dataset/tabular.py
@@ -445,7 +445,7 @@ class TabularDataset(Dataset):
 
         """
         # Get all paths
-        if os.path.isdir(path):
+        if isinstance(path, str) and os.path.isdir(path):
             file_paths = [os.path.join(path, name) for name in os.listdir(path)]
             file_paths = sorted(file_paths)
         else:

--- a/flambe/dataset/tabular.py
+++ b/flambe/dataset/tabular.py
@@ -423,7 +423,8 @@ class TabularDataset(Dataset):
         Parameters
         ----------
         path : str
-            Path to data, could be a directory or a file
+            Path to data, could be a directory, a file, or a
+            smart_open link
         sep: str
             Separator to pass to the `read_csv` method
         header: Optional[Union[str, int]]


### PR DESCRIPTION
Currently, initializing `TabularDataset.from_path()` with a smart_open path to s3 will error when checking if the path is a directory. This change first checks whether the path is a string so that a smart_open path will proceed to `pd.read_csv` and get read normally

```
from smart_open import open as sopen
from flambe.dataset import TabularDataset

data_train = TabularDataset.from_path(train_path=sopen('s3://foo/bar.csv'), sep=',', transform={'text': {'field': my_text_field, 'columns': 0}})
```