### PR TITLE
v0.5: Search module.

### DIFF
--- a/flambe/search/__init__.py
+++ b/flambe/search/__init__.py
@@ -1,0 +1,11 @@
+from flambe.search.distribution import Grid, grid, Choice, choice, Uniform, uniform, \
+    QUniform, quniform, Beta, beta, normal, Normal
+from flambe.search.algorithm import Algorithm, GridSearch, RandomSearch, \
+    BayesOptGP, BayesOptKDE, Hyperband, BOHB
+from flambe.search.search import Search
+
+
+__all__ = ['Grid', 'grid', 'Beta', 'beta', 'Normal', 'normal',
+           'Choice', 'choice', 'Uniform', 'uniform', 'QUniform', 'quniform',
+           'Algorithm', 'BayesOptGP', 'BayesOptKDE', 'BOHB',
+           'GridSearch', 'RandomSearch', 'Hyperband', 'Search']

--- a/flambe/search/algorithm.py
+++ b/flambe/search/algorithm.py
@@ -1,0 +1,326 @@
+from abc import abstractmethod
+from typing import Dict, Optional
+
+from flambe.search.distribution import Distribution
+from flambe.search.trial import Trial
+from flambe.search.space import Space
+from flambe.search.searcher import Searcher, GridSearcher, RandomSearcher,\
+    BayesOptGPSearcher, BayesOptKDESearcher, MultiFidSearcher
+from flambe.search.scheduler import Scheduler, BlackBoxScheduler, HyperBandScheduler
+
+
+class Algorithm(object):
+    """Interface for hyperparameter search algorithms."""
+
+    @abstractmethod
+    def initialize(self, space: Dict[str, Distribution]):
+        """Initialize the algorithm with a search space.
+
+        Parameters
+        ----------
+        trials:
+            Mapping from option name to values.
+
+        """
+        pass
+
+    @abstractmethod
+    def is_done(self) -> bool:
+        """Whether the algorithm has finished producing trials.
+
+        Returns
+        ----------
+        bool
+            ``True`` if the algorithm has terminated.
+
+        """
+        pass
+
+    @abstractmethod
+    def update(self, trials: Dict[str, Trial], maximum: int) -> Dict[str, Trial]:
+        """Update the state of the search.
+
+        Parameters
+        ----------
+        trials: Dict[str, Trial]
+            Mapping from trial id to Trial object.
+        maximum: int
+            The maximum number of new trials to fetch.
+
+        Returns
+        -------
+        Dict[str, Trial]
+            Mapping from trial id to Trial object, after updates.
+
+        """
+        pass
+
+
+class BaseAlgorithm(Algorithm):
+    """Base implementation of a hyperparameter search algorithm."""
+
+    def __init__(self,
+                 searcher: Searcher,
+                 scheduler: Scheduler,
+                 space: Optional[Dict[str, Distribution]] = None):
+        """Initialize a BaseAlgorithm.
+
+        Parameters
+        ----------
+        searcher : Searcher
+            The searcher object to use. See ``Searcher``.
+        scheduler : Scheduler
+            The scheduler object to use. See ``Scheduler``.
+        space : Dict[str, Options], optional
+            A space of hyperparameters to search over.
+
+        """
+        scheduler.link_searcher_fns(searcher.propose_new_params, searcher.register_results)
+
+        self.searcher = searcher
+        self.scheduler = scheduler
+
+        if space is not None:
+            self.initialize(space)
+
+    def initialize(self, space: Dict[str, Distribution]):
+        """Initialize the algorithm with a search space."""
+        self.searcher.assign_space(Space(space))
+
+    def is_done(self) -> bool:
+        """Whether the algorithm has finished producing trials."""
+        return self.scheduler.is_done()
+
+    def update(self, trials: Dict[str, Trial], maximum: int) -> Dict[str, Trial]:
+        """Update the state of the search."""
+        if self.searcher.space is None:
+            raise ValueError('Algorithm has not been initialized with search space.')
+
+        trials = self.scheduler.update_trials(trials)
+        trials = self.scheduler.release_trials(maximum, trials)
+        return trials
+
+
+class GridSearch(BaseAlgorithm):
+
+    def __init__(self,
+                 max_steps: int = 1,
+                 verbose: bool = False,
+                 space: Optional[Dict[str, Distribution]] = None):
+        """The grid search algorithm.
+
+        Simply runs the cross product of all search options.
+
+        Parameters
+        ----------
+        max_steps : int, optional
+            [description], by default 1
+        verbose : bool, optional
+            [description], by default False
+        space : Dict[str, Options], optional
+            A space of hyperparameters to search over.
+
+        """
+        searcher = GridSearcher()
+        scheduler = BlackBoxScheduler(
+            trial_budget=float('inf'),
+            max_steps=max_steps,
+            verbose=verbose
+        )
+        super().__init__(searcher, scheduler)
+
+
+class RandomSearch(BaseAlgorithm):
+
+    def __init__(self,
+                 trial_budget: int,
+                 max_steps: int = 1,
+                 verbose: bool = False,
+                 seed: Optional[int] = None,
+                 space: Optional[Dict[str, Distribution]] = None):
+        """The random search algorithm.
+
+        Samples randomly from the search space.
+
+        Parameters
+        ----------
+        max_steps : int, optional
+            [description], by default 1
+        verbose : bool, optional
+            [description], by default False
+        space : Dict[str, Options], optional
+            A space of hyperparameters to search over.
+        """
+        searcher = RandomSearcher(seed=seed)
+        scheduler = BlackBoxScheduler(
+            max_steps=max_steps,
+            trial_budget=trial_budget,
+            verbose=verbose
+        )
+        super().__init__(searcher, scheduler, space=space)
+
+
+class BayesOptGP(BaseAlgorithm):
+
+    def __init__(self,
+                 trial_budget,
+                 max_steps=1,
+                 verbose=False,
+                 min_configs_in_model=1,
+                 aq_func="ei",
+                 kappa=2.5,
+                 xi=0.0,
+                 seed=None,
+                 space=None):
+        """The BayesOpt algorithm with Gaussian Processes.
+
+        Learns how to search over the space with gaussian processes.
+
+        Parameters
+        ----------
+        max_steps : int, optional
+            [description], by default 1
+        verbose : bool, optional
+            [description], by default False
+        space : Dict[str, Options], optional
+            A space of hyperparameters to search over.
+
+        """
+        searcher = BayesOptGPSearcher(
+            min_configs_in_model=min_configs_in_model,
+            aq_func=aq_func,
+            kappa=kappa,
+            xi=xi,
+            seed=seed
+        )
+        scheduler = BlackBoxScheduler(
+            trial_budget=trial_budget,
+            max_steps=max_steps,
+            verbose=verbose
+        )
+        super().__init__(searcher, scheduler, space=space)
+
+
+class BayesOptKDE(BaseAlgorithm):
+
+    def __init__(self,
+                 trial_budget,
+                 max_steps: int = 1,
+                 verbose: bool = False,
+                 min_configs_per_model: Optional[int] = None,
+                 top_n_frac: float = 0.15,
+                 num_samples: int = 64,
+                 random_fraction: float = 1 / 3,
+                 bandwidth_factor: float = 3,
+                 min_bandwidth: float = 1e-3,
+                 space: Optional[Dict[str, Distribution]] = None):
+        """[summary]
+
+        Parameters
+        ----------
+        max_steps : int, optional
+            [description], by default 1
+        verbose : bool, optional
+            [description], by default False
+        space : Dict[str, Options], optional
+            A space of hyperparameters to search over.
+        """
+        searcher = BayesOptKDESearcher(
+            min_configs_per_model=min_configs_per_model,
+            top_n_frac=top_n_frac,
+            num_samples=num_samples,
+            random_fraction=random_fraction,
+            bandwidth_factor=bandwidth_factor,
+            min_bandwidth=min_bandwidth
+        )
+        scheduler = BlackBoxScheduler(
+            trial_budget=trial_budget,
+            max_steps=max_steps,
+            verbose=verbose
+        )
+        super().__init__(searcher, scheduler, space=space)
+
+
+class Hyperband(BaseAlgorithm):
+
+    def __init__(self,
+                 step_budget: int,
+                 drop_rate: int = 3,
+                 max_steps: int = 1,
+                 verbose: bool = False,
+                 seed: Optional[int] = None,
+                 space: Optional[Dict[str, Distribution]] = None):
+        """[summary]
+
+        Parameters
+        ----------
+        space : [type]
+            [description]
+        max_steps : int, optional
+            [description], by default 1
+        verbose : bool, optional
+            [description], by default False
+
+        """
+        searcher = RandomSearcher(seed=seed)
+        scheduler = HyperBandScheduler(
+            step_budget=step_budget,
+            drop_rate=drop_rate,
+            max_steps=max_steps,
+            verbose=verbose,
+        )
+        super().__init__(searcher, scheduler, space=space)
+
+
+class BOHB(BaseAlgorithm):
+
+    def __init__(self,
+                 step_budget: int,
+                 drop_rate: int = 3,
+                 max_steps: int = 1,
+                 min_steps: int = 1,
+                 top_n_frac: float = 0.15,
+                 num_samples: int = 64,
+                 random_fraction: float = 1 / 3,
+                 bandwidth_factor: int = 3,
+                 min_bandwidth: float = 1e-3,
+                 min_configs_per_model: Optional[int] = None,
+                 verbose: bool = False,
+                 seed: Optional[int] = None,
+                 space: Optional[Dict[str, Distribution]] = None):
+        """The BOHB algorithm.
+
+        Uses bayesopt for selecting new trials, and hyperband to
+        schedule the trials given a budget.
+
+        See: https://arxiv.org/abs/1807.01774.
+
+        Parameters
+        ----------
+        max_steps : int, optional
+            [description], by default 1
+        verbose : bool, optional
+            [description], by default False
+        space : Dict[str, Options], optional
+            A space of hyperparameters to search over.
+
+        """
+        searcher = MultiFidSearcher(
+            BayesOptKDESearcher,
+            {
+                'min_configs_per_model': min_configs_per_model,
+                'top_n_frac': top_n_frac,
+                'num_samples': num_samples,
+                'random_fraction': random_fraction,
+                'bandwidth_factor': bandwidth_factor,
+                'min_bandwidth': min_bandwidth
+            }
+        )
+        scheduler = HyperBandScheduler(
+            step_budget=step_budget,
+            drop_rate=drop_rate,
+            max_steps=max_steps,
+            min_steps=min_steps,
+            verbose=verbose,
+        )
+        super().__init__(searcher, scheduler, space=space)

--- a/flambe/search/distribution/__init__.py
+++ b/flambe/search/distribution/__init__.py
@@ -1,0 +1,33 @@
+from flambe.search.distribution.distribution import Distribution
+from flambe.search.distribution.grid import Grid
+from flambe.search.distribution.choice import Choice
+from flambe.search.distribution.continuous import Uniform, Normal, Beta
+from flambe.search.distribution.discrete import QUniform
+
+
+def grid(*args, **kwargs):
+    return Grid(*args, **kwargs)
+
+
+def choice(*args, **kwargs):
+    return Choice(*args, **kwargs)
+
+
+def normal(*args, **kwargs):
+    return Normal(*args, **kwargs)
+
+
+def beta(*args, **kwargs):
+    return Beta(*args, **kwargs)
+
+
+def uniform(*args, **kwargs):
+    return Uniform(*args, **kwargs)
+
+
+def quniform(*args, **kwargs):
+    return QUniform(*args, **kwargs)
+
+
+__all__ = ['Distribution', 'Uniform', 'Normal', 'Beta', 'uniform', 'normal', 'beta',
+           'QUniform', 'quniform', 'Choice', 'choice', 'Grid', 'grid']

--- a/flambe/search/distribution/choice.py
+++ b/flambe/search/distribution/choice.py
@@ -21,7 +21,6 @@ class Choice(Distribution):
             self.probs = np.array([1 / self.n_options] * self.n_options)
         else:
             self.probs = np.array(probs)
-            assert len(self.options) == len(self.probs)
 
     def sample(self):
         '''

--- a/flambe/search/distribution/choice.py
+++ b/flambe/search/distribution/choice.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+from flambe.compile import alias
+from flambe.search.distribution.distribution import Distribution
+
+
+@alias("~c")
+class Choice(Distribution):
+
+    var_type = 'choice'
+    is_numerical = False
+
+    def __init__(self, options, probs=None):
+        '''
+        choices: List of choices for discrete variable.
+        probs: List of probabilities for the corresponding choices.
+        '''
+        self.n_options = len(options)
+        self.options = np.array(options)
+        if probs is None:
+            self.probs = np.array([1 / self.n_options] * self.n_options)
+        else:
+            self.probs = np.array(probs)
+            assert len(self.options) == len(self.probs)
+
+    def sample(self):
+        '''
+        Sample from the categorical distribution.
+        '''
+        return np.random.choice(self.options, p=self.probs)
+
+    def option_to_int(self, option):
+        '''
+        Convert the choice to a categorical integer.
+
+        choice: One of the possible choices for the variable.
+        '''
+        idx = np.where(self.options == option)[0]
+        if len(idx) == 0:
+            raise ValueError('Value not found in choices!')
+        else:
+            return idx[0]
+
+    def int_to_option(self, idx):
+        '''
+        Convert a categorical integer to a choice.
+
+        int: A value in {0, ..., n_choices-1}.
+        '''
+        return self.options[idx]
+
+    def __iter__(self):
+        yield from list(self.options)
+
+    def __len__(self):
+        return len(self.options)

--- a/flambe/search/distribution/continuous.py
+++ b/flambe/search/distribution/continuous.py
@@ -1,0 +1,71 @@
+import numpy as np
+
+from flambe.compile import alias
+from flambe.search.distribution.numerical import Numerical
+
+
+class Continuous(Numerical):
+    '''
+    Base continuous variable.
+    '''
+    var_type = 'continuous'
+
+
+@alias("~u")
+class Uniform(Continuous):
+
+    def __init__(self, low, high, transform=None):
+        '''
+        low: Minimum value of variable.
+        high: Maximum value of variable.
+        '''
+        if low > high:
+            raise ValueError('Parameter `low`={} cannot be greater '
+                             'than parameter `high`={}.'.format(low, high))
+        super().__init__(var_min=low, var_max=high, transform=transform,
+                         dist_params={'low': low, 'high': high})
+
+    def sample_raw_dist(self):
+        '''
+        Sample from the distribution.
+        '''
+        return np.random.uniform(**self.dist_params)
+
+
+@alias("~n")
+class Normal(Continuous):
+
+    def __init__(self, loc, scale, transform=None):
+        '''
+        loc: Mean of the distribution.
+        scale: Standard deviation of the distribution.
+        '''
+        if scale < 0:
+            raise ValueError('Parameter `scale`={} cannot be less than 0.'.format(scale))
+        super().__init__(var_min=-np.inf, var_max=np.inf, transform=transform,
+                         dist_params={'loc': loc, 'scale': scale})
+
+    def sample_raw_dist(self):
+        '''
+        Sample from the distribution.
+        '''
+        return np.random.normal(**self.dist_params)
+
+
+class Beta(Continuous):
+
+    def __init__(self, a, b, transform=None):
+        '''
+        a: Shape parameter of the distribution.
+        b: Scale parameter of the distribution.
+        '''
+        if a <= 0 or b <= 0:
+            raise ValueError('Parameter `a`={} and `b`={} cannot be non-positive.'.format(a, b))
+        super().__init__(var_min=0, var_max=1, transform=transform,
+                         dist_params={'a': a, 'b': b})
+
+    def sample_raw_dist(self):
+        '''
+        Sample from the distribution.
+        '''
+        return np.random.beta(**self.dist_params)

--- a/flambe/search/distribution/discrete.py
+++ b/flambe/search/distribution/discrete.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+from flamb.compile import alias
+from flambe.search.distribution.numerical import Numerical
+
+
+class Discrete(Numerical):
+    '''
+    Base discrete variable class that inherbits from numerical class.
+    '''
+
+    var_type = 'discrete'
+
+    def __init__(self, options, probs=None, dist_params={}, transform=None):
+        super().__init__(var_min=np.min(options), var_max=np.max(options),
+                         transform=transform, dist_params=dist_params)
+        self.n_options = len(options)
+        self.options = np.array(options)
+        if probs is None:
+            self.probs = np.array([1 / self.n_options] * self.n_options)
+        else:
+            self.probs = np.array(probs)
+            assert len(self.options) == len(self.probs)
+
+    def round_to_options(self, val):
+        '''
+        Find the closest numerical choice for a given value.
+
+        val: The given value.
+        '''
+        argmin = np.argmin([abs(val - c) for c in self.options])
+        return self.options[argmin]
+
+    def sample_raw_dist(self):
+        '''
+        Sample from the distribution.
+        '''
+        return np.random.choice(self.options, p=self.probs)
+
+
+@alias("~qu")
+class QUniform(Discrete):
+    '''
+    Quantized uniform variable class.
+    '''
+
+    def __init__(self, low, high, n, transform=None):
+        '''
+        low: Minimum value.
+        high: Maximum value.
+        n: Number of evenly-spaced choices between [low, high].
+        '''
+        if low > high:
+            raise ValueError('Parameter `low`={} cannot be greater '
+                             'than parameter `high`={}.'.format(low, high))
+        super().__init__(options=np.linspace(low, high, n),
+                         probs=np.array([1 / n] * n),
+                         dist_params={'low': low, 'high': high, 'n': n},
+                         transform=transform)

--- a/flambe/search/distribution/discrete.py
+++ b/flambe/search/distribution/discrete.py
@@ -20,7 +20,6 @@ class Discrete(Numerical):
             self.probs = np.array([1 / self.n_options] * self.n_options)
         else:
             self.probs = np.array(probs)
-            assert len(self.options) == len(self.probs)
 
     def round_to_options(self, val):
         '''

--- a/flambe/search/distribution/distribution.py
+++ b/flambe/search/distribution/distribution.py
@@ -1,0 +1,40 @@
+from abc import abstractmethod
+from typing import Any, Sequence, Dict
+
+from flambe.compile import Registrable
+
+
+class Distribution(Registrable):
+
+    var_type: str
+
+    @abstractmethod
+    def sample(self) -> Any:
+        """Sample from the distribution."""
+        pass
+
+    @classmethod
+    def from_sequence(cls, *args) -> 'Distribution':
+        """Build the distribution from positonal arguments."""
+        return cls(*args)  # type: ignore
+
+    @classmethod
+    def from_dict(cls, **kwargs) -> 'Distribution':
+        """Build the distribution from keyword arguments."""
+        return cls(**kwargs)  # type: ignore
+
+    @classmethod
+    def to_yaml(cls, representer: Any, node: Any, tag: str) -> Any:
+        return representer.represent_sequence(tag, node.elements)
+
+    @classmethod
+    def from_yaml(cls, constructor: Any, node: Any, factory_name: str) -> 'Distribution':
+        args, = list(constructor.construct_yaml_seq(node))
+        if factory_name is None:
+            if isinstance(args, Sequence):
+                return cls(*args)  # type: ignore
+            elif isinstance(args, Dict):
+                return cls(**args)
+        else:
+            factory = getattr(cls, factory_name)
+            return factory(args)

--- a/flambe/search/distribution/grid.py
+++ b/flambe/search/distribution/grid.py
@@ -1,0 +1,35 @@
+from typing import Any, Sequence
+
+from flambe.compile import alias
+from flambe.search.distribution.distribution import Distribution
+
+
+@alias('g')
+class Grid(Distribution):
+    """Discrete set of values used for grid search
+
+    Defines a finite, discrete set of values to be substituted
+    at the location where the set currently resides in the config
+
+    """
+
+    var_type = 'choice'
+    is_numerical = False
+
+    def __init__(self, options: Sequence) -> None:
+        self.options = options
+
+    def sample(self):
+        raise ValueError("Grid options are not meant to be sampled.")
+
+    def __getitem__(self, key: Any) -> Any:
+        return self.options[key]
+
+    def __iter__(self):
+        yield from self.options
+
+    def __len__(self) -> int:
+        return len(self.options)
+
+    def __repr__(self) -> str:
+        return 'gridoptions(' + repr(self.options) + ')'

--- a/flambe/search/distribution/numerical.py
+++ b/flambe/search/distribution/numerical.py
@@ -1,0 +1,76 @@
+from abc import abstractmethod
+
+import numpy as np
+
+from flambe.search.distribution.distribution import Distribution
+
+
+class Numerical(Distribution):
+    '''
+    Base numerical variable class.
+    '''
+
+    is_numerical = True
+
+    def __init__(self, var_min, var_max, transform=None,
+                 dist_params={}):
+        '''
+        var_min: Minimum bound of variable.
+        var_max: Maximum bound of variable.
+        transform: String or custom function for transforming
+        the variable after sampling.  Possible string options
+        include: ['pow2', 'pow10', 'exp'].
+        dist_params: Dictionary denoting the parameters of
+        the distribution.
+        '''
+        self.var_min = var_min
+        self.var_max = var_max
+
+        if transform is None:
+            self.transform_fn = lambda x: x
+        elif transform == 'pow2':
+            self.transform_fn = lambda x: 2**x
+        elif transform == 'pow10':
+            self.transform_fn = lambda x: 10**x
+        elif transform == 'exp':
+            self.transform_fn = lambda x: np.exp(x)
+        else:
+            self.transform_fn = transform
+
+        self.dist_params = dist_params
+
+    def sample(self):
+        '''
+        Sample from the transformed distribution.
+        '''
+        samp = self.sample_raw_dist()
+        return self.transform_fn(samp)
+
+    @abstractmethod
+    def sample_raw_dist(self):
+        '''
+        Sample from the raw distribution.
+        '''
+        pass
+
+    def normalize_to_range(self, val):
+        '''
+        Standardize the variable by its min and max bounds.
+
+        val: Float value of the variable.
+        '''
+        if val < self.var_min or val > self.var_max:
+            raise ValueError('Given value outside of range!')
+        else:
+            return (val - self.var_min) / (self.var_max - self.var_min)
+
+    def unnormalize(self, val):
+        '''
+        Reverse the normalize_to_range function.
+
+        val: Float value of the normalized variable.
+        '''
+        if val < 0 or val > 1:
+            raise ValueError('Normalized value must be between [0, 1].')
+        else:
+            return (self.var_max - self.var_min) * val + self.var_min

--- a/flambe/search/scheduler/__init__.py
+++ b/flambe/search/scheduler/__init__.py
@@ -1,0 +1,6 @@
+from flambe.search.scheduler.scheduler import Scheduler
+from flambe.search.scheduler.fifo import BlackBoxScheduler
+from flambe.search.scheduler.hyperband import HyperBandScheduler
+
+
+__all__ = ['Scheduler', 'BlackBoxScheduler', 'HyperBandScheduler']

--- a/flambe/search/scheduler/fifo.py
+++ b/flambe/search/scheduler/fifo.py
@@ -12,7 +12,8 @@ class BlackBoxScheduler(Scheduler):
         results_file: String to path that results will be logged.
         results_keys: The names of the results that will be stored.
         target_result: The key result for searchers to focus on.
-        n_workers: The maximum number of trials to be released in parallel.
+        n_workers: The maximum number of trials to be released in
+        parallel.
         verbose: Whether or not to print out the results.
         '''
         super().__init__(max_steps, verbose)

--- a/flambe/search/scheduler/fifo.py
+++ b/flambe/search/scheduler/fifo.py
@@ -1,0 +1,66 @@
+from flambe.search.scheduler.scheduler import Scheduler
+
+
+class BlackBoxScheduler(Scheduler):
+    '''
+    Base scheduler class.
+    '''
+
+    def __init__(self, trial_budget, max_steps=1, verbose=False):
+        '''
+        budget: Maximum number of trials to create.
+        results_file: String to path that results will be logged.
+        results_keys: The names of the results that will be stored.
+        target_result: The key result for searchers to focus on.
+        n_workers: The maximum number of trials to be released in parallel.
+        verbose: Whether or not to print out the results.
+        '''
+        super().__init__(max_steps, verbose)
+        self.trial_budget = trial_budget
+        self.num_released = 0
+        self.done = False
+
+    def is_done(self) -> bool:
+        """Whether the algorithm has finished producing trials.
+
+        Returns
+        ----------
+        bool
+            ``True`` if the algorithm has terminated.
+
+        """
+        return self.done or (self.num_released >= self.trial_budget)
+
+    def release_trials(self, n, trials):
+        '''
+        Release a new trial with the corresponding worker id.
+
+        worker_id: The id of the worker in {0, ..., n_workers}.
+        '''
+        while len(trials) < self.trial_budget and n > 0:
+            trial_id, trial = self._create_trial(self.max_steps)
+            if trial is None:
+                self.done = True
+                break
+            else:
+                assert trial_id not in trials.keys()
+                trials[trial_id] = trial
+                n -= 1
+                self.num_released += 1
+        return trials
+
+    def update_trials(self, trials):
+        '''
+        Update the algorithm with trial results.
+
+        worker_id: The id of the worker in {0, ..., n_workers}.
+        trial_id: String denoting the id of the trial.
+        results: Dictionary of results to log.
+        '''
+        trials_with_result = {trial_id: trial for trial_id,
+                              trial in trials.items() if trial.has_result()}
+        results_dict = {t_id: trial.best_metric for t_id, trial in trials_with_result.items()}
+        self._register_results(results_dict)
+        for trial in trials_with_result.values():
+            trial.set_terminated()
+        return trials

--- a/flambe/search/scheduler/fifo.py
+++ b/flambe/search/scheduler/fifo.py
@@ -43,7 +43,6 @@ class BlackBoxScheduler(Scheduler):
                 self.done = True
                 break
             else:
-                assert trial_id not in trials.keys()
                 trials[trial_id] = trial
                 n -= 1
                 self.num_released += 1

--- a/flambe/search/scheduler/hyperband.py
+++ b/flambe/search/scheduler/hyperband.py
@@ -1,0 +1,173 @@
+import numpy as np
+
+from flambe.search.scheduler.scheduler import Scheduler
+
+
+class HyperBandScheduler(Scheduler):
+
+    def __init__(self, step_budget, max_steps, min_steps=1, drop_rate=3, verbose=False):
+        '''
+        n_workers: The maximum number of trials to be released in parallel.
+        results_file: String to path that results will be logged.
+        results_keys: The names of the results that will be stored.
+        target_result: The key result for searchers to focus on.
+        max_steps: Maximum number of resources to allocate to a single trial.
+        min_steps: Minimum number of resources to allocate to a single trial.
+        n_bracket_runs: Number of iterations of the outer loop of HyperBand
+        to run.
+        drop_rate: The factor by which trials are ended after each successive
+        halving iteration.
+        res_is_int: Whether or not to truncate resources to nearest integer.
+        verbose: Whether or not to print out results.
+        '''
+        super().__init__(max_steps, verbose)
+        self.min_steps = min_steps
+        self.drop_rate = drop_rate
+
+        # Initialize HyperBand params
+        self.max_drops = int(np.log(max_steps / min_steps) / np.log(drop_rate))
+        n_drops_grid = np.arange(self.max_drops + 1)
+        self.n_trials_grid = np.ceil((self.max_drops + 1) / (n_drops_grid + 1) *
+                                     (drop_rate**n_drops_grid)).astype('int')
+        self.n_res_grid = max_steps / (drop_rate**n_drops_grid)
+
+        self.step_budget = step_budget
+        self.n_bracket_runs = self.step_budget // ((self.max_drops + 1) * self.max_steps)
+
+        # Keep track of each bracket
+        self.brackets = []
+        for br in range(self.n_bracket_runs):
+            s = self.max_drops - br % (self.max_drops + 1)
+            self.brackets.append(Bracket(self.n_trials_grid[s], s))
+
+        self.bracket_ids = {}
+
+    def is_done(self) -> bool:
+        """Whether the algorithm has finished producing trials.
+
+        Returns
+        ----------
+        bool
+            ``True`` if the algorithm has terminated.
+
+        """
+        return all(bracket.has_finished for bracket in self.brackets)
+
+    def release_trials(self, n, trials):
+        '''
+        Release a new trial with the corresponding worker id.
+
+        worker_id: The id of the worker in {0, ..., n_workers}.
+        '''
+        for br, bracket in enumerate(self.brackets):
+            s = bracket.max_halvings
+
+            while n > 0 and (not bracket.has_finished) and bracket.has_pending:
+                trial_id = bracket.get_pending()
+                n_res_init = self.n_res_grid[s]
+
+                if trial_id is None:
+                    # Create new trial
+                    trial_id, trial = self._create_trial(int(n_res_init))
+                    assert trial is not None
+                    assert trial_id not in trials.keys()
+                    trials[trial_id] = trial
+                else:
+                    # Resume previously paused trial
+                    trial = trials[trial_id]
+                    assert trial.is_paused()
+                    # n_res_curr = len(trial.metrics)
+                    # n_res_total = n_res_init * (self.drop_rate**bracket.n_halvings)
+                    # TODO trial.append_steps(int(n_res_total - n_res_curr))
+                    trial.set_resume()
+
+                self.bracket_ids[trial_id] = br
+                n -= 1
+
+        return trials
+
+    def update_trials(self, trials):
+        '''
+        Update the algorithm with trial results.
+
+        worker_id: The id of the worker in {0, ..., n_workers}.
+        trial_id: String denoting the id of the trial.
+        results: Dictionary of results to log.
+        '''
+
+        # Send results back to searcher
+        trials_with_result = {trial_id: trial for trial_id,
+                              trial in trials.items() if trial.has_result()}
+        results_dict = {t_id: trial.best_metric for t_id, trial in trials_with_result.items()}
+        fids_dict = {t_id: len(trial.metrics) for t_id, trial in trials_with_result.items()}
+        self._register_results(results_dict, fids_dict=fids_dict)
+
+        # Update brackets with results
+        for trial_id, trial in trials_with_result.items():
+            br = self.bracket_ids[trial_id]
+            bracket = self.brackets[br]
+            s = bracket.max_halvings
+            bracket.record_finished(trial_id, trial.get_metric(-1))
+            trial.set_paused()
+
+            if bracket.is_ready_for_halving:
+                n_trials_init = self.n_trials_grid[s]
+                i = bracket.n_halvings + 1
+                n_active = int(n_trials_init / (self.drop_rate**i))
+                non_active_trial_ids = bracket.execute_halving(n_active)
+                for trial_id in non_active_trial_ids:
+                    trials[trial_id].set_terminated()
+
+            elif bracket.has_finished:
+                trial_ids = [x[0] for x in bracket.finished]
+                for trial_id in trial_ids:
+                    trials[trial_id].set_terminated()
+        return trials
+
+
+class Bracket:
+    '''
+    Internal hyperband data structure.
+    '''
+
+    def __init__(self, n_trials, max_halvings):
+        self.n_trials = n_trials
+        self.n_halvings = 0
+        self.max_halvings = max_halvings
+        self.pending = [None] * n_trials
+        self.finished = []
+
+    def get_pending(self):
+        return self.pending.pop()
+
+    def record_finished(self, trial, result):
+        self.finished.append((trial, result))
+        assert len(self.finished) <= self.n_trials
+
+    @property
+    def has_pending(self):
+        return len(self.pending) > 0
+
+    @property
+    def is_ready_for_halving(self):
+        return (self.n_halvings < self.max_halvings) & (self.n_trials == len(self.finished))
+
+    @property
+    def has_finished(self):
+        return (self.n_halvings == self.max_halvings) & (self.n_trials == len(self.finished))
+
+    def execute_halving(self, n_active):
+        assert self.is_ready_for_halving
+        trials_sorted = sorted(self.finished, key=lambda x: x[1], reverse=True)
+        trials_sorted = [x[0] for x in trials_sorted]
+        active_trials = trials_sorted[:n_active]
+        non_active_trials = trials_sorted[n_active:]
+
+        self.n_trials = n_active
+        self.pending = active_trials
+        np.random.shuffle(self.pending)
+
+        self.finished = []
+
+        self.n_halvings += 1
+        return non_active_trials

--- a/flambe/search/scheduler/hyperband.py
+++ b/flambe/search/scheduler/hyperband.py
@@ -69,13 +69,10 @@ class HyperBandScheduler(Scheduler):
                 if trial_id is None:
                     # Create new trial
                     trial_id, trial = self._create_trial(int(n_res_init))
-                    assert trial is not None
-                    assert trial_id not in trials.keys()
                     trials[trial_id] = trial
                 else:
                     # Resume previously paused trial
                     trial = trials[trial_id]
-                    assert trial.is_paused()
                     # n_res_curr = len(trial.metrics)
                     # n_res_total = n_res_init * (self.drop_rate**bracket.n_halvings)
                     # TODO trial.append_steps(int(n_res_total - n_res_curr))
@@ -142,7 +139,6 @@ class Bracket:
 
     def record_finished(self, trial, result):
         self.finished.append((trial, result))
-        assert len(self.finished) <= self.n_trials
 
     @property
     def has_pending(self):
@@ -157,7 +153,6 @@ class Bracket:
         return (self.n_halvings == self.max_halvings) & (self.n_trials == len(self.finished))
 
     def execute_halving(self, n_active):
-        assert self.is_ready_for_halving
         trials_sorted = sorted(self.finished, key=lambda x: x[1], reverse=True)
         trials_sorted = [x[0] for x in trials_sorted]
         active_trials = trials_sorted[:n_active]

--- a/flambe/search/scheduler/hyperband.py
+++ b/flambe/search/scheduler/hyperband.py
@@ -7,17 +7,21 @@ class HyperBandScheduler(Scheduler):
 
     def __init__(self, step_budget, max_steps, min_steps=1, drop_rate=3, verbose=False):
         '''
-        n_workers: The maximum number of trials to be released in parallel.
+        n_workers: The maximum number of trials to be released in
+            parallel.
         results_file: String to path that results will be logged.
         results_keys: The names of the results that will be stored.
         target_result: The key result for searchers to focus on.
-        max_steps: Maximum number of resources to allocate to a single trial.
-        min_steps: Minimum number of resources to allocate to a single trial.
-        n_bracket_runs: Number of iterations of the outer loop of HyperBand
-        to run.
-        drop_rate: The factor by which trials are ended after each successive
-        halving iteration.
-        res_is_int: Whether or not to truncate resources to nearest integer.
+        max_steps: Maximum number of resources to allocate to a single
+            trial.
+        min_steps: Minimum number of resources to allocate to a single
+            trial.
+        n_bracket_runs: Number of iterations of the outer loop of
+        HyperBandto run.
+        drop_rate: The factor by which trials are ended after each
+        successive halving iteration.
+        res_is_int: Whether or not to truncate resources to nearest
+        integer.
         verbose: Whether or not to print out results.
         '''
         super().__init__(max_steps, verbose)

--- a/flambe/search/scheduler/scheduler.py
+++ b/flambe/search/scheduler/scheduler.py
@@ -1,0 +1,76 @@
+from abc import ABC, abstractmethod
+
+from flambe.search.trial import Trial
+
+
+class Scheduler(ABC):
+    '''
+    Base scheduler class.
+    '''
+
+    def __init__(self, max_steps=1, verbose=False):
+        '''
+        results_file: String to path that results will be logged.
+        results_keys: The names of the results that will be stored.
+        target_result: The key result for searchers to focus on.
+        n_workers: The maximum number of trials to be released in parallel.
+        verbose: Whether or not to print out the results.
+        '''
+        self.trials = {}
+        self.max_steps = max_steps
+        self.verbose = verbose
+
+        self._propose_new_params = None
+        self._register_results = None
+
+    def link_searcher_fns(self, propose_new_params_fn, register_results_fn):
+        '''
+        Link the searcher's propose_new_hp and register_hps functions to the scheduler.
+        '''
+        self._propose_new_params = propose_new_params_fn
+        self._register_results = register_results_fn
+
+    @abstractmethod
+    def is_done(self) -> bool:
+        """Whether the algorithm has finished producing trials.
+
+        Returns
+        ----------
+        bool
+            ``True`` if the algorithm has terminated.
+
+        """
+        pass
+
+    @abstractmethod
+    def release_trials(self, n, trials_paused):
+        '''
+        Return a new trial for the user.
+
+        worker_id: The id of the worker.
+        '''
+        pass
+
+    @abstractmethod
+    def update_trials(self, trial_ids):
+        '''
+        Update results from the user.
+
+        worker_id: The id of the worker.
+        trial_id: The id of the trial.
+        results: Dictionary of results.
+        '''
+        pass
+
+    def _create_trial(self, n_steps, **kwargs):
+        '''
+        Create a new trial.
+        '''
+        # Create trial
+        trial_id, params = self._propose_new_params(**kwargs)
+        if params is None:
+            return None, None
+        else:
+            # TODO: pass n_steps?
+            new_trial = Trial(params)
+            return trial_id, new_trial

--- a/flambe/search/search.py
+++ b/flambe/search/search.py
@@ -1,0 +1,244 @@
+
+from typing import Tuple, Optional, Callable, Dict, List, Any
+import os
+import subprocess
+
+import ray
+
+import flambe as fl
+from flambe.compile import Schema
+from flambe.search.trial import Trial
+from flambe.search.algorithm import Algorithm
+from flambe.search.distribution import Grid
+
+
+class Task(object):
+    """Temporary dummy."""
+
+    def step(self) -> bool:
+        pass
+
+    def metric(self) -> float:
+        pass
+
+
+class TaskAdapter:
+
+    """Perform computation of a task."""
+
+    def __init__(self, schema: Schema) -> None:
+        """Initialize the Trial.
+
+        Parameters
+        ----------
+        partial: partial[Task]
+
+        """
+        self.schema = schema
+        self.task: Optional[Task] = None
+
+    def step(self) -> Tuple[bool, Optional[float]]:
+        """Run a step of the Trial"""
+        if self.task is None:
+            self.task = self.schema.compile()
+
+        continue_ = self.task.step()
+        metric = self.task.metric()
+        return continue_, metric
+
+    def kill(self) -> None:
+        ray.actor.exit_actor()
+
+
+class CallableAdapter:
+
+    """Perform computation of a function."""
+
+    def __init__(self, schema: Schema) -> None:
+        """Initialize the Trial.
+
+        Parameters
+        ----------
+        partial: partial[Task]
+
+        """
+        self.schema = schema
+        self.callable: Optional[Callable] = None
+
+    def step(self) -> Tuple[bool, Optional[float]]:
+        """Run a step of the Trial"""
+        self.callable = self.callable or self.schema()
+        continue_ = False
+        metric = self.callable()
+        return continue_, metric
+
+    def kill(self) -> None:
+        ray.actor.exit_actor()
+
+
+class Checkpointer(object):
+
+    def __init__(self,
+                 path: str,
+                 host: str,
+                 memory: bool = False,
+                 local_dir: Optional[str] = None):
+
+        self.object_id = None
+        self.memory = memory
+        self.path = os.path.join(path, '')
+        self.remote = f"{host}:{self.path}"
+
+    def get_checkpoint(self) -> Optional[Task]:
+        if self.memory:
+            if self.object_id is None:
+                return None
+            return ray.get(self.object_id)
+        else:
+            if not os.path.exists(self.path):
+                os.mkdir(self.path)
+            subprocess.run(f'rsync -a {self.remote} {self.path}')
+            return fl.load(self.path)
+
+    def set_checkpoint(self, task: Task):
+        if self.memory:
+            del self.object_id
+            self.object_id = ray.put(task)
+        else:
+            fl.save(task, self.path)
+            subprocess.run(f'rsync -a {self.path} {self.remote}')
+
+
+class Search(object):
+    """Implement a hyperparameter search over any schema.
+
+    Use a Search to construct a hyperparameter search over any
+    objects. Takes as input a schema to search, and algorithm,
+    and resources to allocate per variant.
+
+    Example
+    -------
+
+    >>> task = Schema(Task, arg1=uniform(0, 1), arg2=choice('a', 'b'))
+    >>> search = Search(task, algorithm=Hyperband())
+    >>> search.run()
+
+    """
+    def __init__(self,
+                 schema: Schema,
+                 algorithm: Algorithm,
+                 cpus_per_trial: int = 1,
+                 gpus_per_trial: int = 0,
+                 ouput_dir: Optional[str] = None,
+                 refresh_waitime: float = 1.0) -> None:
+        """Initialize a hyperparameter search.
+
+        Parameters
+        ----------
+        schema : Schema[Task]
+            A schema of the callable or Task to search
+        algorithm : Algorithm
+            The hyperparameter search algorithm
+        cpus_per_trial : int
+            The number of cpu's to allocate per trial
+        gpus_per_trial : int
+                The number of gpu's to allocate per trial
+        refresh_waitime : float, optional
+            The minimum amount of time to wait before a refresh.
+            Defaults ``10`` seconds.
+
+        """
+        self.output_dir = ouput_dir
+        self.n_cpus = cpus_per_trial
+        self.n_gpus = gpus_per_trial
+        self.refresh_waitime = refresh_waitime
+
+        total_resources = ray.cluster_resources()
+        if self.n_cpus > 0 and self.n_cpus > total_resources['CPU']:
+            raise ValueError("# of CPUs required per trial is larger than the total available.")
+        elif self.n_gpus > 0 and self.n_gpus > total_resources['GPU']:
+            raise ValueError("# of CPUs required per trial is larger than the total available.")
+
+        # Check schema
+        if any(isinstance(dist, Grid) for dist in schema.search_space()):
+            raise ValueError("Schema cannot contain grid options, please split first.")
+
+        self.schema = schema
+        self.algorithm = algorithm
+
+        if issubclass(self.schema._cls, Task):
+            self.adatper = ray.remote(num_cpus=self.n_cpus, num_gpus=self.n_gpus)(TaskAdapter)
+        elif isinstance(self.schema._cls, Callable):  # type: ignore
+            self.adatper = ray.remote(num_cpus=self.n_cpus, num_gpus=self.n_gpus)(CallableAdapter)
+        else:
+            raise ValueError("Only functions and Task objects supported.")
+
+    def run(self) -> List[Trial]:
+        """Execute the search.
+
+        Returns
+        -------
+        List[Trial]
+
+        """
+        self.algorithm.initialize(self.schema.search_space())
+
+        running: List[int] = []
+        finished: List[int] = []
+
+        trials: Dict[str, Trial] = dict()
+        id_to_trial_name: Dict[str, str] = dict()
+        trial_name_to_actor: Dict[str, Any] = dict()
+
+        while running or (not self.algorithm.is_done()):
+            # Get all the current object ids running
+            if running:
+                finished, running = ray.wait(running, timeout=self.refresh_waitime)
+
+            # Process finished trials
+            for object_id in finished:
+                _continue, metric = ray.get(object_id)
+                trial = trials[id_to_trial_name[str(object_id)]]
+
+                if _continue:
+                    trial.set_metric(metric)
+                    trial.set_has_result()
+                else:
+                    trial.set_terminated()
+
+            # Update the algorithm
+            max_queries = 0
+            current_resources = ray.available_resources()
+            if self.n_cpus > 0 and self.n_gpus > 0:
+                n_possible_cpu = current_resources.get('CPU', 0) // self.n_cpus
+                n_possible_gpu = current_resources.get('GPU', 0) // self.n_gpus
+                max_queries = min(n_possible_cpu, n_possible_gpu)
+            elif self.n_cpus > 0:
+                max_queries = current_resources.get('CPU', 0) // self.n_cpus
+            elif self.n_gpus > 0:
+                max_queries = current_resources.get('GPU', 0) // self.n_gpus
+
+            trials = self.algorithm.update(trials, maximum=max_queries)
+
+            # Update based on trial status
+            for name, trial in trials.items():
+                # Handle creation and termination
+                if trial.is_paused() or trial.is_running():
+                    continue
+                elif trial.is_terminated() and name in trial_name_to_actor:
+                    del trial_name_to_actor[name]
+                elif trial.is_created():
+                    partial = self.schema.set_params(trial.parameters)
+                    actor = self.adatper.remote(partial)
+                    trial_name_to_actor[name] = actor
+                    trial.set_resume()
+
+                # Launch created and resumed
+                if trial.is_resuming():
+                    actor = trial_name_to_actor[name]
+                    object_id = actor.step.remote()
+                    running.append(object_id)
+                    id_to_trial_name[str(object_id)] = name
+                    trial.set_running()
+
+        return list(trials.values())

--- a/flambe/search/searcher/__init__.py
+++ b/flambe/search/searcher/__init__.py
@@ -1,0 +1,9 @@
+from flambe.search.searcher.searcher import Searcher
+from flambe.search.searcher.grid import GridSearcher
+from flambe.search.searcher.random import RandomSearcher
+from flambe.search.searcher.bayesian import BayesOptGPSearcher, BayesOptKDESearcher
+from flambe.search.searcher.multifid import MultiFidSearcher
+
+
+__all__ = ['Searcher', 'GridSearcher', 'RandomSearcher',
+           'BayesOptGPSearcher', 'BayesOptKDESearcher', 'MultiFidSearcher']

--- a/flambe/search/searcher/bayesian.py
+++ b/flambe/search/searcher/bayesian.py
@@ -24,7 +24,8 @@ class BayesOptGPSearcher(ModelBasedSearcher):
         space: A hypertune.space.Space object.
         min_points_in_model: Minimum number of points
                              before model-based searching starts.
-        aq_func: Aquisition function type; possibilities: "ei", "ucb", "poi".
+        aq_func: Aquisition function type; possibilities:
+            "ei", "ucb", "poi".
         kappa: Acquisition function parameter `kappa`.
         xi: Acquisition function parameter `xi`.
         seed: Seed for the searcher.
@@ -109,11 +110,16 @@ class BayesOptKDESearcher(ModelBasedSearcher):
                  random_fraction=1 / 3, bandwidth_factor=3, min_bandwidth=1e-3):
         '''
         space: A hypertune.space.Space object.
-        min_points_per_model: Integer denoting minimum number of points before model building.
-        top_n_frac: Fraction of points to use for building the "good" model.
-        num_samples: Number of samples for optimizing the acquisition function.
-        random_fraction: Fraction of time to return a randomly generated sample.
-        bandwidth_factor: Algorithm parameter for encouraging exploration.
+        min_points_per_model: Integer denoting minimum number of
+            points before model building.
+        top_n_frac: Fraction of points to use for building the
+            "good" model.
+        num_samples: Number of samples for optimizing the acquisition
+            function.
+        random_fraction: Fraction of time to return a randomly generated
+            sample.
+        bandwidth_factor: Algorithm parameter for encouraging
+            exploration.
         min_bandwidth: Minimum bandwidth.
         '''
 

--- a/flambe/search/searcher/bayesian.py
+++ b/flambe/search/searcher/bayesian.py
@@ -1,0 +1,246 @@
+from scipy.stats import truncnorm
+from statsmodels.nonparametric.kernel_density import KDEMultivariate
+from bayes_opt import BayesianOptimization, UtilityFunction
+import numpy as np
+
+from flambe.search.searcher.searcher import ModelBasedSearcher
+
+
+class BayesOptGPSearcher(ModelBasedSearcher):
+    '''
+    Bayesian optimization search models the hyperparameter space
+    with a Gaussian process surrogate function and uses Bayesian
+    principles to iteratively propose configurations that trade
+    off exploration and exploitation.
+
+    Wraps around BayesianOptimization library:
+    https://github.com/fmfn/BayesianOptimization.
+
+    '''
+
+    def __init__(self, min_configs_in_model=1, aq_func="ei",
+                 kappa=2.5, xi=0.0, seed=None):
+        '''
+        space: A hypertune.space.Space object.
+        min_points_in_model: Minimum number of points
+                             before model-based searching starts.
+        aq_func: Aquisition function type; possibilities: "ei", "ucb", "poi".
+        kappa: Acquisition function parameter `kappa`.
+        xi: Acquisition function parameter `xi`.
+        seed: Seed for the searcher.
+        '''
+
+        super().__init__(min_configs_in_model)
+
+        self.aq_func = aq_func
+        self.kappa = kappa
+        self.xi = xi
+        self.seed = seed
+
+    @classmethod
+    def _check_space(cls, space):
+        '''
+        Check if the space is valid for this algorithm.
+
+        space: A hypertune.space.Space object.
+        '''
+        if np.any(np.array(space.var_types) == 'choice'):
+            raise ValueError('For grid search, all dimensions \
+                             must be `continuous` or `discrete`!')
+
+    def assign_space(self, space):
+
+        super().assign_space(space)
+
+        # Initialize BayesOpt library objects
+        self.optimizer = BayesianOptimization(
+            f=None,
+            pbounds={n: b for n, b in zip(self.space.var_names, self.space.var_bounds)},
+            verbose=0,
+            random_state=self.seed
+        )
+        self.utility = UtilityFunction(self.aq_func, self.kappa, self.xi)
+
+    def _propose_new_params_in_model_space(self, **kwargs):
+        '''
+        Uses the GP and acquisition function to propose a
+        new (unrounded) hyperparameter configuration.
+        '''
+        # Ensure there are no proposed trials awaiting result
+        if np.any([x['result'] is None for x in self.data.values()]):
+            raise ValueError('Gaussian Process searcher cannot propose new\
+                             configuration with missing result.')
+
+        rand_samp = self.space.sample_raw_dist(**kwargs)
+        if rand_samp is None:
+            return self.optimizer.suggest(self.utility)
+        else:
+            return rand_samp
+
+    def _apply_transform(self, params_in_model_space):
+        params_in_raw_dist_space = self.space.round_to_space(params_in_model_space)
+        params = self.space.apply_transform(params_in_raw_dist_space)
+        return params
+
+    def register_results(self, results, **kwargs):
+        '''
+        Fit a GP on the new results.
+
+        hp_results: List of hyperparameters and targets to record.
+        '''
+        super().register_results(results, **kwargs)
+
+        for params_id in results.keys():
+            self.optimizer.register(params=self.data[params_id]['params_in_model_space'],
+                                    target=self.data[params_id]['result'])
+
+
+class BayesOptKDESearcher(ModelBasedSearcher):
+    '''
+    Adapted from:
+    https://github.com/automl/HpBandSter/blob/master/hpbandster/optimizers/config_generators/bohb.py
+
+    Mathematical details can be found in:
+    https://bookdown.org/egarpor/NP-UC3M/kre-ii-multmix.html
+
+    '''
+
+    def __init__(self, min_configs_per_model=None, top_n_frac=0.15, num_samples=64,
+                 random_fraction=1 / 3, bandwidth_factor=3, min_bandwidth=1e-3):
+        '''
+        space: A hypertune.space.Space object.
+        min_points_per_model: Integer denoting minimum number of points before model building.
+        top_n_frac: Fraction of points to use for building the "good" model.
+        num_samples: Number of samples for optimizing the acquisition function.
+        random_fraction: Fraction of time to return a randomly generated sample.
+        bandwidth_factor: Algorithm parameter for encouraging exploration.
+        min_bandwidth: Minimum bandwidth.
+        '''
+
+        self.top_n_frac = top_n_frac
+        self.bw_factor = bandwidth_factor
+        self.min_bw = min_bandwidth
+
+        self.num_samples = num_samples
+        self.random_fraction = random_fraction
+
+        self.good_kde = None
+        self.bad_kde = None
+
+        self.min_configs_per_model = min_configs_per_model
+        if min_configs_per_model:
+            super().__init__(min_configs_per_model + 2)
+        else:
+            super().__init__(-1)
+
+    def assign_space(self, space):
+
+        super().assign_space(space)
+
+        if self.min_configs_per_model is None:
+            self.min_configs_per_model = self.space.n_vars + 1
+            self.min_configs_in_model = self.min_configs_per_model + 2
+
+        if self.min_configs_per_model < self.space.n_vars + 1:
+            raise ValueError('Parameter min_points_in_model cannot be \
+                             less than one plus the number of hyperparameters.')
+
+        self.kde_vartypes = [vt[0] for vt in self.space.var_types]
+
+    @classmethod
+    def _check_space(cls, space):
+        '''
+        Check if the space is valid for this algorithm.
+
+        space: A hypertune.space.Space object.
+        '''
+        if np.any([x == 'discrete' for x in space.var_types]):
+            raise ValueError('BayesOpt KDE Searcher does not support \
+                             distributions with `var_type=discrete`!')
+
+    def _propose_new_params_in_model_space(self, **kwargs):
+        '''
+        Propose new model hyperparameters.
+        '''
+
+        rand_samp = super()._propose_new_params_in_model_space(**kwargs)
+        if rand_samp is not None:
+            return self.space.normalize_to_space(rand_samp)
+
+        if np.random.uniform() < self.random_fraction:
+            return self.space.normalize_to_space(self.space.sample_raw_dist())
+
+        best = np.inf
+        best_hp = None
+
+        def func_to_min(x):
+            return max(1e-32, self.bad_kde.pdf(x)) / max(self.good_kde.pdf(x), 1e-32)
+
+        for _ in range(self.num_samples):
+
+            # Sample from KDE
+            idx = np.random.randint(0, len(self.good_kde.data))
+            datum = self.good_kde.data[idx]
+            sample_hp = []
+
+            for m, bw, dist in zip(datum, self.good_kde.bw, self.space.dists):
+                bw = max(bw, self.min_bw)
+                if dist.var_type == 'continuous':
+                    bw = self.bw_factor * bw
+                    sample_hp.append(truncnorm.rvs(-m / bw, (1 - m) / bw, loc=m, scale=bw))
+
+                elif dist.var_type == 'choice':
+                    bw = min(bw, 1)  # Probability cannot be greater than 1
+                    if np.random.rand() < 1 - bw:
+                        sample_hp.append(int(m))
+                    else:
+                        # technically should exclude m
+                        sample_hp.append(np.random.randint(dist.n_options))
+                else:
+                    raise ValueError('Unknown var type!')
+
+            val = func_to_min(sample_hp)
+            if val < best:
+                best = val
+                best_hp = sample_hp
+
+        best_hp_dict = {n: hp for n, hp in zip(self.space.var_names, best_hp)}
+        return best_hp_dict
+
+    def _apply_transform(self, params_in_model_space):
+        params_in_raw_dist_space = self.space.unnormalize(params_in_model_space)
+        params = self.space.apply_transform(params_in_raw_dist_space)
+        return params
+
+    def register_results(self, results, **kwargs):
+        '''
+        Fit a KDE on the new results.
+
+        hp_results: List of hyperparameters and targets to record.
+        '''
+
+        super().register_results(results, **kwargs)
+
+        if self.has_enough_configs_for_model:
+
+            train_data = [list(x['params_in_model_space'].values()) for x in self.data.values()]
+            train_results = [x['result'] for x in self.data.values()]
+
+            min_configs = self.min_configs_per_model
+            n_good = max(min_configs, int(self.top_n_frac * min_configs))
+            n_bad = max(min_configs, self.n_configs_in_model - n_good)
+
+            idx = np.argsort(train_results)[::-1]
+            good_train_data = np.array(train_data)[idx[:n_good]]
+            bad_train_data = np.array(train_data)[idx[-n_bad:]]
+
+            # Fit KDE
+            self.good_kde = KDEMultivariate(data=good_train_data,
+                                            var_type=self.kde_vartypes,
+                                            bw='normal_reference')
+            self.bad_kde = KDEMultivariate(data=bad_train_data,
+                                           var_type=self.kde_vartypes,
+                                           bw='normal_reference')
+
+            self.good_kde.bw = np.clip(self.good_kde.bw, self.min_bw, None)
+            self.bad_kde.bw = np.clip(self.bad_kde.bw, self.min_bw, None)

--- a/flambe/search/searcher/grid.py
+++ b/flambe/search/searcher/grid.py
@@ -1,0 +1,57 @@
+import itertools
+import numpy as np
+
+from flambe.search.searcher.searcher import Searcher
+
+
+class GridSearcher(Searcher):
+    '''
+    Grid search does a brute force search over all
+    discretized hyperparameter configurations.
+    '''
+
+    def assign_space(self, space):
+        '''
+        space: A hypertune.space.Space object.
+        '''
+        super().assign_space(space)
+
+        params_options = {name: d.options for name, d in self.space.distributions.items()}
+        self.params_sets = self._dict_to_cartesian_list(params_options)
+
+    @classmethod
+    def _check_space(self, space):
+        '''
+        Check if the space is valid for this algorithm.
+
+        space: A hypertune.space.Space object.
+        '''
+        if np.any(np.array(space.var_types) == 'continuous'):
+            raise ValueError('For grid search, all dimensions must be `discrete` or `choice`!')
+
+    def _dict_to_cartesian_list(self, d):
+        '''
+        Generates a list of the Cartesian product between
+        hyperparameter options contained in dictionary format.
+
+        d: Dictionary of choices.
+        '''
+        lst = []
+        for key in d:
+            lst.append([(key, val) for val in d[key]])
+        cartesian_lst = list(itertools.product(*lst))[::-1]
+        return cartesian_lst
+
+    def _propose_new_params(self):
+        '''
+        Returns a hyperparameter configuration from the
+        list of Cartesian products.
+        '''
+        if bool(self.params_sets):
+            new_params = dict(self.params_sets.pop())
+            return new_params
+        else:
+            return None
+
+    def register_results(self, results, **kwargs):
+        pass

--- a/flambe/search/searcher/multifid.py
+++ b/flambe/search/searcher/multifid.py
@@ -1,0 +1,79 @@
+import numpy as np
+
+from flambe.search.searcher.searcher import ModelBasedSearcher
+
+
+class MultiFidSearcher(ModelBasedSearcher):
+    '''
+    A searcher that allows for multiple fidelities --
+    meant to be paired with HyperBand scheduler.
+    '''
+
+    def __init__(self, searcher_class, search_kwargs):
+        '''
+        searcher_class: A subclass of ModelBasedSearcher.
+        search_kwargs: The parameters of the searcher_class.
+        '''
+
+        self.searcher_class = searcher_class
+        self.search_kwargs = search_kwargs
+        self.searchers = {}
+        self.max_fid = -np.inf
+        self.max_fid_searcher = self.searcher_class(**self.search_kwargs)
+
+        super().__init__(min_configs_in_model=0)
+
+    def _check_space(self, space):
+        '''
+        Check if the space is valid for this algorithm.
+
+        space: A hypertune.space.Space object.
+        '''
+        self.max_fid_searcher._check_space(space)
+
+    def assign_space(self, space):
+        super().assign_space(space)
+        self.max_fid_searcher.assign_space(space)
+
+    def _propose_new_params_in_model_space(self):
+        return self.max_fid_searcher._propose_new_params_in_model_space()
+
+    def _apply_transform(self, params_in_model_space):
+        return self.max_fid_searcher._apply_transform(params_in_model_space)
+
+    def register_results(self, results, fids_dict):
+
+        # Group param_ids by fidelity
+        fids_groups = {}
+        for param_id, fid in fids_dict.items():
+            if fid in fids_groups:
+                fids_groups[fid].add(param_id)
+            else:
+                fids_groups[fid] = set([param_id])
+
+        for fid, params_ids in fids_groups.items():
+
+            # Do not need to train the model if fidelity is less than max
+            if fid < self.max_fid:
+                continue
+
+            if fid in self.searchers.keys():
+                searcher = self.searchers[fid]
+            else:
+                searcher = self.searcher_class(**self.search_kwargs)
+                searcher.assign_space(self.space)
+                self.searchers[fid] = searcher
+
+            # Transfer data from multifidelity searcher to subsearcher
+            for params_id in params_ids:
+                params_in_model_space = self.data[params_id]['params_in_model_space']
+                searcher.data[params_id] = {'params_in_model_space': params_in_model_space,
+                                            'result': None}
+
+            filtered_results = {p_id: res for p_id, res in results.items() if p_id in params_ids}
+            searcher.register_results(filtered_results)
+
+            # Check if max fidelity searcher should be updated
+            if fid > self.max_fid and searcher.has_enough_configs_for_model:
+                self.max_fid = fid
+                self.max_fid_searcher = searcher

--- a/flambe/search/searcher/random.py
+++ b/flambe/search/searcher/random.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from flambe.search.searcher.searcher import Searcher
+
+
+class RandomSearcher(Searcher):
+    '''
+    Random search samples parameterized distributions for
+    hyperparameters.  At the moment, this searcher
+    only supports an independent distribution for each hyperparameter.
+    '''
+
+    def __init__(self, seed=None):
+        '''
+        space: A hypertune.space.Space object.
+        seed: Seed for the random generator.
+        '''
+
+        if seed:
+            np.random.seed(seed)
+
+        super().__init__()
+
+    def _propose_new_params(self, **kwargs):
+        '''
+        Samples a single hyperparameter configuration
+        from parameterized distributions.
+        '''
+        return self.space.sample()
+
+    def register_results(self, results, **kwargs):
+        pass

--- a/flambe/search/searcher/searcher.py
+++ b/flambe/search/searcher/searcher.py
@@ -105,5 +105,4 @@ class ModelBasedSearcher(Searcher):
         hp_results: List of hyperparameters and associated results.
         '''
         for params_id, result in results.items():
-            assert self.data[params_id]['result'] is None
             self.data[params_id]['result'] = result

--- a/flambe/search/searcher/searcher.py
+++ b/flambe/search/searcher/searcher.py
@@ -1,0 +1,109 @@
+from abc import ABC, abstractmethod
+
+
+class Searcher(ABC):
+    '''
+    Base searcher class.  Searchers handle hyperparameter
+    configuration selection and only  have access to a) the
+    hyperparameters that need to be tuned and b) the performance of
+    these hyperparameters.
+    '''
+
+    def __init__(self):
+        self.space = None
+
+    def assign_space(self, space):
+        self._check_space(space)
+        self.space = space
+        self.n_configs_proposed = 0
+
+    @classmethod
+    def _check_space(cls, space):
+        pass
+
+    def propose_new_params(self, **kwargs):
+        '''
+        Proposes a new hyperparameter configuration based on
+        internal searching algorithm.  All
+        subclasses must implement this method.
+        '''
+        if self.space is None:
+            raise ValueError('Space has not been assigned to searcher.')
+        params_id = self.n_configs_proposed
+        params = self._propose_new_params(**kwargs)
+        if params is None:
+            return None, None
+        else:
+            self.n_configs_proposed += 1
+            return params_id, params
+
+    @abstractmethod
+    def _propose_new_params(self, **kwargs):
+        pass
+
+    @abstractmethod
+    def register_results(self, results, **kwargs):
+        pass
+
+
+class ModelBasedSearcher(Searcher):
+
+    def __init__(self, min_configs_in_model):
+        '''
+        space: A hypertune.space.Space object.
+        min_points_in_model: Minimum number of points
+        to collect before model building.
+        '''
+        super().__init__()
+        self.min_configs_in_model = min_configs_in_model
+        self.data = {}
+
+    @property
+    def n_configs_in_model(self):
+        return sum([1 for datum in self.data.values() if datum['result'] is not None])
+
+    @property
+    def has_enough_configs_for_model(self):
+        '''
+        Check if the searcher has enough points to build a model.
+        '''
+        return self.n_configs_in_model >= self.min_configs_in_model
+
+    def _propose_new_params(self, **kwargs):
+        '''
+        Propose a new hyperparameter configuration.
+        Calls internal self._propose_new_model_hp
+        function and applies the transforms from the space.
+        Note that model building happens
+        in the distribution space (not the transformed space).
+        '''
+        params_in_model_space = self._propose_new_params_in_model_space(**kwargs)
+        params_id = self.n_configs_proposed
+        self.data[params_id] = {'params_in_model_space': params_in_model_space,
+                                'result': None}
+
+        params = self._apply_transform(params_in_model_space)
+        return params
+
+    @abstractmethod
+    def _propose_new_params_in_model_space(self, **kwargs):
+        '''
+        Subclasses must override this method that
+        generates samples in the distribution space.
+        '''
+        if not self.has_enough_configs_for_model:
+            return self.space.sample_raw_dist()
+
+    @abstractmethod
+    def _apply_transform(self, params_in_model_space):
+        pass
+
+    def register_results(self, results, **kwargs):
+        '''
+        Record results.
+
+        hp_results: List of hyperparameters and associated results.
+        '''
+        for params_id, result in results.items():
+            assert self.data[params_id]['result'] is None
+            self.data[params_id]['result'] = result

--- a/flambe/search/space.py
+++ b/flambe/search/space.py
@@ -1,0 +1,145 @@
+from typing import Dict
+
+import numpy as np
+
+from flambe.search.distribution import Distribution
+
+
+class Space(object):
+    """Search space object.
+
+    Manages the various dimensions that the hyperparameters are in.
+    This object is used internally by the search aglrothms and should
+    not be used directly.
+
+
+    """
+
+    def __init__(self, distributions: Dict[str, Distribution]):
+        '''
+        Initialize the search space with a list of search distributions.
+
+        search_dists: List of search distributions, e.g.
+
+            from hypertune.space import Choice, Uniform
+            search_dists = [Choice('hp1', [5, 6, 7]),
+                     Uniform('hp2', low=3, high=7, transform='pow10')]
+        '''
+        self.distributions = distributions
+        self.var_names = list(distributions.keys())
+        self.dists = [distributions[name] for name in self.var_names]
+        self.n_vars = len(self.dists)
+
+        self.var_types = [dist.var_type for dist in self.dists]
+        self.var_bounds = [(dist.var_min, dist.var_max) if dist.is_numerical
+                           else (np.nan, np.nan) for dist in self.dists]
+
+        self.name2idx = {name: i for i, name in enumerate(self.var_names)}
+
+        # Check that all var names are unique
+        assert len(self.name2idx.keys()) == self.n_vars
+
+    def sample(self):
+        '''
+        Randomly sample from the space.
+        '''
+        samp = {}
+        for name, dist in self.distributions.items():
+            samp[name] = dist.sample()
+        return samp
+
+    def sample_raw_dist(self):
+        '''
+        Randomly sample from the raw distributions
+        without applying transforms.
+        '''
+        samp = {}
+        for name, dist in self.distributions.items():
+            if dist.is_numerical:
+                s = dist.sample_raw_dist()
+            else:
+                s = dist.sample()
+            samp[name] = s
+        return samp
+
+    def apply_transform(self, samp):
+        '''
+        Apply transforms to a sample drawn from the space
+        using sample_dist.
+
+        samp: Dictionary of hyperparameter values, e.g.
+                    samp = {'hp1': 7, 'hp2': 3}
+        '''
+        transformed = {}
+        for var_name in samp.keys():
+            dist = self.dists[self.name2idx[var_name]]
+            if dist.is_numerical:
+                t = dist.transform_fn(samp[var_name])
+            else:
+                t = samp[var_name]
+            transformed[var_name] = t
+        return transformed
+
+    def round_to_space(self, hp_dict):
+        '''
+        Round hyperparameters to possible choices for ordered variables.
+
+        hp_dict: Dictionary of hyperparameter values.
+        '''
+        rounded = {}
+        for name in hp_dict.keys():
+            dist = self.dists[self.name2idx[name]]
+            val = hp_dict[name]
+
+            if dist.var_type == 'discrete':
+                val = dist.round_to_options(val)
+
+            rounded[name] = val
+        return rounded
+
+    def normalize_to_space(self, hp_dict, return_as_list=False):
+        '''
+        Normalize hyperparameters to [0, 1] based on range for
+        numerical variables and convert them to integers for
+        categorical variables.
+
+        hp_dict: Dictionary of hyperparameter values.
+        return_as_list: Whether or not to return the hyperparameters as a list.
+        '''
+        normalized = {}
+        for name in hp_dict.keys():
+            dist = self.dists[self.name2idx[name]]
+            val = hp_dict[name]
+
+            if dist.is_numerical:
+                val = dist.normalize_to_range(val)
+            else:
+                val = dist.option_to_int(val)
+            normalized[name] = val
+
+        if return_as_list:
+            lst = []
+            for name in self.var_names:
+                if name in normalized.keys():
+                    lst.append(normalized[name])
+            return lst
+        else:
+            return normalized
+
+    def unnormalize(self, hp_dict):
+        '''
+        Reverse the normalize_to_space function.
+
+        hp_dict: Dictionary of normalized hyperparameter values.
+        '''
+        unnormalized = {}
+        for name in hp_dict.keys():
+            dist = self.dists[self.name2idx[name]]
+            val = hp_dict[name]
+
+            if dist.is_numerical:
+                val = dist.unnormalize(val)
+            else:
+                val = dist.int_to_option(val)
+            unnormalized[name] = val
+        return unnormalized

--- a/flambe/search/space.py
+++ b/flambe/search/space.py
@@ -101,7 +101,8 @@ class Space(object):
         categorical variables.
 
         hp_dict: Dictionary of hyperparameter values.
-        return_as_list: Whether or not to return the hyperparameters as a list.
+        return_as_list: Whether or not to return the
+            hyperparameters as a list.
         '''
         normalized = {}
         for name in hp_dict.keys():

--- a/flambe/search/space.py
+++ b/flambe/search/space.py
@@ -31,13 +31,10 @@ class Space(object):
         self.n_vars = len(self.dists)
 
         self.var_types = [dist.var_type for dist in self.dists]
-        self.var_bounds = [(dist.var_min, dist.var_max) if dist.is_numerical
+        self.var_bounds = [(dist.var_min, dist.var_max) if dist.is_numerical  # type: ignore
                            else (np.nan, np.nan) for dist in self.dists]
 
         self.name2idx = {name: i for i, name in enumerate(self.var_names)}
-
-        # Check that all var names are unique
-        assert len(self.name2idx.keys()) == self.n_vars
 
     def sample(self):
         '''

--- a/flambe/search/trial.py
+++ b/flambe/search/trial.py
@@ -1,0 +1,169 @@
+import enum
+from typing import Dict, Any, List, Optional
+
+
+class Status(enum.Enum):
+    """The set of valid status for a trial.
+
+    - `CREATED`: the trial is ready for execution
+    - `RUNNING`: the trial is currently executing
+    - `PAUSED`: the trial was paused by the search algorithm
+    - `RESUME`: the trial is ready to be resumed
+    - `HAS_RESULT`: the trial has a new result
+    - `TERMINATED`: the trial ran successfully
+    - `ERROR`: the trial has an error
+
+    """
+    CREATED = 0
+    RUNNING = 1
+    PAUSED = 2
+    RESUME = 3
+    HAS_RESULT = 4
+    TERMINATED = 5
+    ERROR = 6
+
+
+class Trial(object):
+    """An abstract representation of a trial.
+
+    A Trial object has three main attributes that can be read
+    and modified, namely: `status`, `metrics` and `parameters`.
+
+    """
+    def __init__(self, params: Dict[str, Any]):
+        """Initialize a Trial.
+
+        Parameters
+        ----------
+        params : Dict[str, Any]
+            Set of hyperparameters to use for this trial.
+
+        """
+        self.params = params
+        self.status = Status.CREATED
+        self.metrics: List[float] = []
+
+    @property
+    def parameters(self) -> Dict[str, Any]:
+        """Get the set of hyperparameters for this trial."""
+        return self.params
+
+    @property
+    def best_metric(self) -> Optional[float]:
+        """Get the best metric recorded so far."""
+        return max(self.metrics) if self.metrics else None
+
+    def get_metric(self, step: int) -> float:
+        """Get the current trial results."""
+        if self.metrics is None:
+            raise ValueError("No metrics available.")
+        elif step - 1 > len(self.metrics):
+            raise ValueError(f"This trial only has {len(self.metrics)}, \
+                             but step #{step} was requested")
+        return self.metrics[step]
+
+    def get_status(self) -> Status:
+        """Get the current trial status."""
+        return self.status
+
+    def set_metric(self, metric: float, step: int = None):
+        """Set the current trial results. #1 indexed."""
+        if step and step < len(self.metrics):
+            raise ValueError("Attempting to erase previous metric")
+        elif step and step > len(self.metrics):
+            raise ValueError(f"Step ({step}) is bigger than the expected \
+                               step value ({len(self.metrics) + 1}).")
+        self.metrics.append(metric)
+
+    def set_status(self, status: Status):
+        """Set the status of this trial."""
+        self.status = status
+
+    def is_running(self) -> bool:
+        """Whether the trial is currently running."""
+        return self.status == Status.RUNNING
+
+    def has_result(self) -> bool:
+        """Whether the trial has a new result to report."""
+        return self.status == Status.HAS_RESULT
+
+    def is_paused(self) -> bool:
+        """Whether the trial is currently paused"""
+        return self.status == Status.PAUSED
+
+    def is_resuming(self) -> bool:
+        """Whether the trial should resume execution."""
+        return self.status == Status.RESUME
+
+    def is_terminated(self) -> bool:
+        """Whether the trial was terminated."""
+        return self.status == Status.TERMINATED
+
+    def is_error(self) -> bool:
+        """Whether the trial ended with an error."""
+        return self.status == Status.ERROR
+
+    def is_created(self) -> bool:
+        """Whether the trial was just created."""
+        return self.status == Status.CREATED
+
+    def set_running(self):
+        """Sets the trial status to running."""
+        self.status = Status.RUNNING
+
+    def set_has_result(self):
+        """Sets the trial status to has result."""
+        self.status = Status.HAS_RESULT
+
+    def set_paused(self):
+        """Sets the trial status to pause."""
+        self.status = Status.PAUSED
+
+    def set_resume(self):
+        """Sets the trial status to resume."""
+        self.status = Status.RESUME
+
+    def set_terminated(self):
+        """Sets the trial status to terminated."""
+        self.status = Status.TERMINATED
+
+    def set_error(self):
+        """Sets the trial status to error."""
+        self.status = Status.ERROR
+
+    def set_created(self):
+        """Sets the trial status to created."""
+        self.status = Status.CREATED
+
+    def generate_name(self, prefix: str = '') -> str:
+        """Generate a name for this parameter variant.
+
+        Parameters
+        ----------
+        params: Any
+            Parameter object to parse. Can be a sequence, mapping, or
+            any other Python object.
+        prefix: str, optional
+            A prefix to add to the generated name.
+
+        Returns
+        -------
+        str
+            A string name to represent the variant when dumping results.
+
+        """
+        def helper(params):
+            if isinstance(params, (list, tuple, set)):
+                name = ",".join([helper(param) for param in params])
+                name = f"[{name}]"
+            elif isinstance(params, dict):
+                name = '|'
+                for param, value in params.items():
+                    if isinstance(value, dict):
+                        name += helper({f'{param}.{k}': v for k, v in value.items()})[1:]
+                    else:
+                        name += f'{param}={helper(value)}|'
+            else:
+                name = str(params)
+
+        return prefix + helper(self.parameters)


### PR DESCRIPTION
This PR introduces the new search module, which effectively replaces Ray Tune. It includes:

- A set of distributions to use to specify hyperparameters: grid, choice, uniform, normal, quniform (i.e quantized), beta
- A set of hyperparameter search algorithms: GridSearch, RandomSearch, BayesOptGP, BayesOptKDE, Hyperband and BOHB.
- A `Search` object which, given a schema and an algorithm, executes a distributed hyperparameter search.

Notes about the PR:

- The class `Trial` and `Space` are internal to the module, and not meant to be used directly by a user. Instead, the main entry point should be the `Search` object.
- Still requires some tests (to be added in a later PR)
- As discussed offline, this PR is meant to be merged in the refactor branch.