### PR TITLE
use the build badge from shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
 
 |
 
-.. image:: https://circleci.com/gh/asappresearch/flambe.svg?style=svg
+.. image:: https://img.shields.io/circleci/build/github/asappresearch/flambe
     :target: https://circleci.com/gh/asappresearch/flambe
 
 .. image:: https://readthedocs.org/projects/flambe/badge/?version=latest


### PR DESCRIPTION
I never liked the default circle ci badge. This way, it's a lot cleaner and more consistent!