### PR TITLE
Extra validation metrics are provided as key-value mapping rather tha…

### DIFF
--- a/flambe/learn/distillation.py
+++ b/flambe/learn/distillation.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, List
+from typing import Optional, Tuple, Dict
 
 import torch
 import torch.nn.functional as F
@@ -41,7 +41,7 @@ class DistillationTrainer(Trainer):
                  lower_is_better: bool = False,
                  max_grad_norm: Optional[float] = None,
                  max_grad_abs_val: Optional[float] = None,
-                 extra_validation_metrics: Optional[List[Metric]] = None,
+                 extra_validation_metrics: Optional[Dict[str, Metric]] = None,
                  teacher_columns: Optional[Tuple[int, ...]] = None,
                  student_columns: Optional[Tuple[int, ...]] = None,
                  alpha_kl: float = 0.5,

--- a/flambe/learn/train.py
+++ b/flambe/learn/train.py
@@ -93,7 +93,7 @@ class Trainer(Component):
         max_grad_abs_val: float, optional
             Maximum absolute value of all gradient vector components
             after clipping.
-        extra_validation_metrics: Optional[List[Metric]]
+        extra_validation_metrics: Optional[Dict[str, Metric]]
             A list with extra metrics to show in each step
             but which don't guide the training procedures
             (i.e model selection through early stopping)
@@ -111,7 +111,7 @@ class Trainer(Component):
         self.lower_is_better = lower_is_better
         self.max_grad_norm = max_grad_norm
         self.max_grad_abs_val = max_grad_abs_val
-        self.extra_validation_metrics = extra_validation_metrics or []
+        self.extra_validation_metrics = extra_validation_metrics or {}
 
         # By default, no prefix applied to tb logs
         self.tb_log_prefix = None
@@ -296,8 +296,8 @@ class Trainer(Component):
         log(f'{tb_prefix}Validation/Loss', val_loss, self._step)
         log(f'{tb_prefix}Validation/{self.metric_fn}', val_metric, self._step)
         log(f'{tb_prefix}Best/{self.metric_fn}', self._best_metric, self._step)  # type: ignore
-        for metric in self.extra_validation_metrics:
-            log(f'{tb_prefix}Validation/{metric}',
+        for metric_name, metric in self.extra_validation_metrics.items():
+            log(f'{tb_prefix}Validation/{metric_name}',
                 metric(preds, targets).item(), self._step)  # type: ignore
 
     def run(self) -> bool:

--- a/flambe/learn/train.py
+++ b/flambe/learn/train.py
@@ -94,9 +94,11 @@ class Trainer(Component):
             Maximum absolute value of all gradient vector components
             after clipping.
         extra_validation_metrics: Optional[Dict[str, Metric]]
-            A list with extra metrics to show in each step
+            A dict with extra metrics to show in each step
             but which don't guide the training procedures
             (i.e model selection through early stopping)
+            The key of the metric will be used for displaying
+            the values in tensorboard.
 
         """
         self.dataset = dataset

--- a/flambe/learn/train.py
+++ b/flambe/learn/train.py
@@ -45,7 +45,7 @@ class Trainer(Component):
                  lower_is_better: bool = False,
                  max_grad_norm: Optional[float] = None,
                  max_grad_abs_val: Optional[float] = None,
-                 extra_validation_metrics: Optional[List[Metric]] = None) -> None:
+                 extra_validation_metrics: Optional[Dict[str, Metric]] = None) -> None:
         """Initialize an instance of Trainer
 
         Parameters

--- a/tests/integration/end2end/tc.yaml
+++ b/tests/integration/end2end/tc.yaml
@@ -34,5 +34,5 @@ pipeline:
     max_steps: 1
     iter_per_step: 1
     extra_validation_metrics:
-      - !@ b1[metric_fn]
-      - !@ b1[metric_fn]
+      m1: !@ b1[metric_fn]
+      m2: !@ b1[metric_fn]


### PR DESCRIPTION
…n a List

This allows you to have multiple metrics of the same class with different configurations. When provided as a list, they're written to tensorboard using the class name, so metrics of the same class are overwritten. A mapping allows each metric object to have a unique name.