### PR TITLE
Goodbye automatic install feature

### DIFF
--- a/docs/understanding/runnables.rst
+++ b/docs/understanding/runnables.rst
@@ -105,10 +105,10 @@ We can execute:
 
   flambe s3pusher.yaml --secrets secret.ini
 
-.. _understanding-automatic-install_label: 
+.. _understanding-extensions-install_label: 
 
-Automatic extensions installation
----------------------------------
+Extensions installation
+-----------------------
 
 .. important::
     To understand this section you should be familiar with extensions. For information about
@@ -126,20 +126,13 @@ When executing a :class:`~flambe.runnable.Runnable`, it's possible that extensio
         ...
         param: !other_ext.CustomComponent
 
-Flambé provides a ``-i / --install-extensions`` flag to automatically "pip" installs the extensions:
-
-.. code:: bash
-
-  flambe custom_runnable.yaml -i
-
-
-By default, this is **not** activated and the user needs to install the extensions
-beforehand.
+These extensions need to be installed in order to run the ``Runnable``. Users can easily do this using ``pip``, as the
+extensions are just python packages.
 
 .. warning::
-   **Installing extensions automatically could possibly update libraries in the your
-   environment because of a version reequirement.** Flambé will output all libraries that
-   are being updated.
+   The extensions section (as seen in the example above) contains a dictionary where the key is the module name
+   and the value is the package. **The package is the one that the user needs to ``pip`` install.
+   are being updated.**
 
 Other flags
 -----------

--- a/flambe/compile/extensions.py
+++ b/flambe/compile/extensions.py
@@ -4,7 +4,6 @@ This module provides methods to orchestrate all extensions
 
 import os
 from shutil import which
-import re
 
 from urllib.parse import urlparse
 from git import Repo, NoSuchPathError
@@ -12,7 +11,7 @@ import subprocess
 
 import importlib
 import importlib.util
-from typing import Dict, Optional, Iterable, Union
+from typing import Dict, Optional, Iterable
 from flambe.logging import coloredlogs as cl
 from flambe.compile.utils import _is_url
 

--- a/flambe/runner/run.py
+++ b/flambe/runner/run.py
@@ -60,10 +60,8 @@ def main(args: argparse.Namespace) -> None:
     with SafeExecutionContext(args.config) as ex:
         if args.cluster is not None:
             with SafeExecutionContext(args.cluster) as ex_cluster:
-                cluster, _ = ex_cluster.preprocess(secrets=args.secrets,
-                                                   install_ext=args.install_extensions)
-                runnable, extensions = ex.preprocess(import_ext=False,
-                                                     check_tags=False,
+                cluster, cluster_extensions = ex_cluster.preprocess(secrets=args.secrets)
+                runnable, extensions = ex.preprocess(check_tags=False,
                                                      secrets=args.secrets)
                 cluster.run(force=args.force, debug=args.debug)
                 if isinstance(runnable, ClusterRunnable):
@@ -86,7 +84,6 @@ def main(args: argparse.Namespace) -> None:
                     new_secrets = cluster.send_secrets()
 
                     # Installing the extensions is crutial as flambe
-                    # will execute without '-i' flag and therefore
                     # will assume that the extensions are installed
                     # in the orchestrator.
                     cluster.install_extensions_in_orchestrator(new_extensions)
@@ -99,8 +96,7 @@ def main(args: argparse.Namespace) -> None:
                 else:
                     raise ValueError("Only ClusterRunnables can be executed in a cluster.")
         else:
-            runnable, _ = ex.preprocess(secrets=args.secrets,
-                                        install_ext=args.install_extensions)
+            runnable, _ = ex.preprocess(secrets=args.secrets)
             runnable.run(force=args.force, verbose=args.verbose, debug=args.debug)
 
 
@@ -110,9 +106,6 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Run a flambé!')
     parser.add_argument('config', type=str, help='Path to config file')
-    parser.add_argument('-i', '--install-extensions', action='store_true', default=False,
-                        help='Install extensions automatically using pip. WARNING: ' +
-                             'This could potentially override already installed packages.')
     parser.add_argument('-c', '--cluster', type=str, default=None,
                         help='Specify the cluster that will run the experiment. This option ' +
                              'works if the main config is an Experiment')


### PR DESCRIPTION
This PR removes completely the automatic install feature from flambe. **We decided this feature tries to solve a problem that is not inside flambe's scope, and the current implementation provides more problems than solutions**.

Moving forward, the user will be responsible for installing extensions before using the runnables. Additionally, we are evaluating building supporting tools to deal with the extensions' installation process easier, but they won't be part of the flambe package.