### PR TITLE
Fix '-f' bug in first time remote experiments

### DIFF
--- a/flambe/experiment/experiment.py
+++ b/flambe/experiment/experiment.py
@@ -26,6 +26,7 @@ from flambe.experiment.options import ClusterResource
 from flambe.runnable import RemoteEnvironment
 from flambe.runnable import error
 from flambe.runnable import utils as run_utils
+from flambe.runner.utils import get_files
 from flambe.experiment.progress import ProgressState
 from flambe.experiment.tune_adapter import TuneAdapter
 from flambe.logging import coloredlogs as cl
@@ -194,11 +195,8 @@ class Experiment(ClusterRunnable):
 
         # Check if save_path/name already exists + is not empty
         # + force and resume are False
-        if (
-            os.path.exists(self.full_save_path) and
-            os.listdir(self.full_save_path) and
-            not self.resume and not force
-        ):
+        if not self.resume and not force and os.path.exists(self.full_save_path) \
+                and list(get_files(self.full_save_path)):
             raise error.ParsingRunnableError(
                 f"Results from an experiment with the same name were located in the save path " +
                 f"{self.full_save_path}. To overide this results, please use '--force' " +

--- a/flambe/runner/utils.py
+++ b/flambe/runner/utils.py
@@ -1,5 +1,6 @@
 import os
 import logging
+from typing import Iterable
 
 from flambe.const import FLAMBE_GLOBAL_FOLDER
 from flambe.experiment.wording import print_extensions_cache_size_warning
@@ -9,6 +10,28 @@ logger = logging.getLogger(__name__)
 
 MB = 2**20
 WARN_LIMIT_MB = 100
+
+
+def get_files(path: str) -> Iterable[str]:
+    """Return the list of all files (recursively)
+    a directory has.
+
+    Parameters
+    ----------
+    path: str
+        The directory's path
+
+    Return
+    ------
+    List[str]
+        The list of files (each file with its path from
+        the given parameter)
+
+    """
+    for dirpath, dirnames, filenames in os.walk(path):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            yield fp
 
 
 def get_size_MB(path: str) -> float:
@@ -27,11 +50,9 @@ def get_size_MB(path: str) -> float:
     """
     accum = 0
     if os.path.isdir(path):
-        for dirpath, dirnames, filenames in os.walk(path):
-            for f in filenames:
-                fp = os.path.join(dirpath, f)
-                if os.path.exists(fp) and not os.path.islink(fp):
-                    accum += os.path.getsize(fp)
+        for fp in get_files(path):
+            if os.path.exists(fp) and not os.path.islink(fp):
+                accum += os.path.getsize(fp)
     else:
         accum = os.path.getsize(path)
     return accum / MB

--- a/flambe/runner/utils.py
+++ b/flambe/runner/utils.py
@@ -27,11 +27,22 @@ def get_files(path: str) -> Iterable[str]:
         The list of files (each file with its path from
         the given parameter)
 
+    Raise
+    -----
+    ValueError
+        In case the path does not exist
+
     """
-    for dirpath, dirnames, filenames in os.walk(path):
-        for f in filenames:
-            fp = os.path.join(dirpath, f)
-            yield fp
+    if not os.path.exists(path):
+        raise ValueError(f"{path} does not exist")
+
+    def _wrapped():
+        for dirpath, dirnames, filenames in os.walk(path):
+            for f in filenames:
+                fp = os.path.join(dirpath, f)
+                yield fp
+
+    return _wrapped()
 
 
 def get_size_MB(path: str) -> float:

--- a/tests/unit/runner/test_utils.py
+++ b/tests/unit/runner/test_utils.py
@@ -40,3 +40,8 @@ def test_get_files():
         open(f2, 'w+').close()
 
         assert list(utils.get_files(t)) == [f1, f2]
+
+
+def test_get_files_invalid():
+    with pytest.raises(ValueError):
+        utils.get_files('/some/non/existent/path/to/test')

--- a/tests/unit/runner/test_utils.py
+++ b/tests/unit/runner/test_utils.py
@@ -8,7 +8,7 @@ from flambe.runner import utils
 MB = 2 ** 20
 
 
-def create_file(filename, size_MB = 1):
+def create_file(filename, size_MB=1):
     # From https://stackoverflow.com/a/8816154
     with open(filename, "wb") as out:
         out.truncate(size_MB * MB)
@@ -29,3 +29,14 @@ def test_size_MB_folder(mbs):
         create_file(os.path.join(t, '3.bin'), size_MB=mbs)
         create_file(os.path.join(t, '4.bin'), size_MB=mbs)
         assert utils.get_size_MB(t) == 4 * mbs
+
+
+def test_get_files():
+    with tempfile.TemporaryDirectory() as t:
+        f1 = os.path.join(t, 'some_file.txt')
+        os.mkdir(os.path.join(t, 'folder'))
+        f2 = os.path.join(t, 'folder', 'some_file.txt')
+        open(f1, 'w+').close()
+        open(f2, 'w+').close()
+
+        assert list(utils.get_files(t)) == [f1, f2]


### PR DESCRIPTION
There is a bug currently that doesn't allow to run remote experiments if the `-f` flag is not provided (even if its the first time the cluster is being used).

This PR solves this bug.