### PR TITLE
dill 0.2.9 is incompatible with torch 1.3, upgrading to 0.3.1 solves

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ GitPython~=2.1.11
 sru==2.1.9
 pygments~=2.3.1
 nltk~=3.4.1
-dill==0.2.9
+dill>=0.3.1
 gensim==3.7.3
 pip~=19.1
 awscli==1.16.202


### PR DESCRIPTION
This allows model loading to work with pytorch 1.3