### PR TITLE
Save eval metric

### DIFF
--- a/flambe/learn/eval.py
+++ b/flambe/learn/eval.py
@@ -49,7 +49,6 @@ class Evaluator(Component):
         self.eval_sampler = eval_sampler or BaseSampler(batch_size=16, shuffle=False)
         self.model = model
         self.metric_fn = metric_fn
-        self.eval_metric = None
         self.dataset = dataset
 
         self.device = select_device(device)
@@ -59,6 +58,9 @@ class Evaluator(Component):
 
         # By default, no prefix applied to tb logs
         self.tb_log_prefix = None
+
+        self.eval_metric = None
+        self.register_attrs('eval_metric')
 
     def run(self, block_name: str = None) -> bool:
         """Run the evaluation.


### PR DESCRIPTION
`eval_metric` will be available when `flambe.load('/path/to/evaluator')`