### PR TITLE
fix serialization tests

### DIFF
--- a/tests/unit/compile/test_serialization.py
+++ b/tests/unit/compile/test_serialization.py
@@ -523,7 +523,13 @@ class TestSerializationIntegration:
 
     def test_save_to_file_and_load_from_file_roundtrip_complex(self, complex_multi_layered):
         TORCH_TAG_PREFIX = "torch"
-        make_component(torch.nn.Module, TORCH_TAG_PREFIX, only_module='torch.nn')
+        exclude = ['torch.nn.quantized', 'torch.nn.qat']
+        make_component(
+            torch.nn.Module,
+            TORCH_TAG_PREFIX,
+            only_module='torch.nn',
+            exclude=exclude
+        )
         old_obj = complex_multi_layered(from_config=True)
         # Test that the current state is actually saved, for a
         # Component-only child of torch objects
@@ -547,7 +553,13 @@ class TestSerializationIntegration:
     def test_save_to_file_and_load_from_file_roundtrip_complex_nontorch_root(self,
             complex_multi_layered_nontorch_root, pickle_only, compress_save_file):
         TORCH_TAG_PREFIX = "torch"
-        make_component(torch.nn.Module, TORCH_TAG_PREFIX, only_module='torch.nn')
+        exclude = ['torch.nn.quantized', 'torch.nn.qat']
+        make_component(
+            torch.nn.Module,
+            TORCH_TAG_PREFIX,
+            only_module='torch.nn',
+            exclude=exclude
+        )
         old_obj = complex_multi_layered_nontorch_root(from_config=True)
         state = old_obj.get_state()
         with tempfile.TemporaryDirectory() as root_path:
@@ -711,10 +723,16 @@ class TestSerializationExtensions:
         In this case we will use a config containing torch, but we will make_component
         on torch so that it can be compiled. After that, we add_extensions_metadata with
         torch, which is a valid extensions for the config (redundant, but valid).
-        
+
         """
         TORCH_TAG_PREFIX = "torch"
-        make_component(torch.nn.Module, TORCH_TAG_PREFIX, only_module='torch.nn')
+        exclude = ['torch.nn.quantized', 'torch.nn.qat']
+        make_component(
+            torch.nn.Module,
+            TORCH_TAG_PREFIX,
+            only_module='torch.nn',
+            exclude=exclude
+        )
 
         config = """
         !torch.Linear
@@ -738,10 +756,16 @@ class TestSerializationExtensions:
         In this case we will use a config containing torch, but we will make_component
         on torch so that it can be compiled. After that, we add_extensions_metadata with
         torch, which is a valid extensions for the config (redundant, but valid).
-        
+
         """
         TORCH_TAG_PREFIX = "torch"
-        make_component(torch.nn.Module, TORCH_TAG_PREFIX, only_module='torch.nn')
+        exclude = ['torch.nn.quantized', 'torch.nn.qat']
+        make_component(
+            torch.nn.Module,
+            TORCH_TAG_PREFIX,
+            only_module='torch.nn',
+            exclude=exclude
+        )
 
         schema = complex_multi_layered_nontorch_root(from_config=True, schema=True)
         schema.add_extensions_metadata({"torch": "torch"})


### PR DESCRIPTION
The update allowing torch 1.3 had to add in some special logic to avoid registering some new classes with the same name (torch's Linear in qat); but we missed a few places, specifically test cases in the serialization unit tests.