### PR TITLE
Change python 3.x for 3.6 and 3.7

### DIFF
--- a/.github/workflows/tests-slow.yml
+++ b/.github/workflows/tests-slow.yml
@@ -9,6 +9,7 @@ on:
  
 jobs:
   examples:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/tests-slow.yml
+++ b/.github/workflows/tests-slow.yml
@@ -10,13 +10,15 @@ on:
 jobs:
   examples:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7]
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
-        python-version: '3.x'
+        python-version: ${{ matrix.python-version }}
     - name: Cache pip
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
This PR fixes the fact that the slow tests are running with `3.8` where `torch~=1.3.0` is not found. We currently support `3.6` and `3.7`.