### PR TITLE
Change comparison when loading from pickle to not break when comparing tensors

### DIFF
--- a/flambe/compile/component.py
+++ b/flambe/compile/component.py
@@ -368,7 +368,11 @@ class PickledDataLink(Registrable):
 
     def __call__(self, stash: Dict[str, Any]) -> Any:
         if self.obj_value is not None:
-            if self.obj_value != stash[self.obj_id]:
+            diff_obj_stash = self.obj_value != stash[self.obj_id]
+            is_tensor = type(diff_obj_stash) == torch.Tensor
+
+            # == comparison between tensors returns a tensor, not bool
+            if (is_tensor and torch.any(diff_obj_stash)) or (not is_tensor and diff_obj_stash):
                 warn("PickledDataLink called second time with different stash")
             return self.obj_value
         self.obj_value = stash[self.obj_id]

--- a/flambe/compile/component.py
+++ b/flambe/compile/component.py
@@ -369,7 +369,7 @@ class PickledDataLink(Registrable):
     def __call__(self, stash: Dict[str, Any]) -> Any:
         if self.obj_value is not None:
             diff_obj_stash = self.obj_value != stash[self.obj_id]
-            is_tensor = type(diff_obj_stash) == torch.Tensor
+            is_tensor = isinstance(diff_obj_stash, torch.Tensor)
 
             # == comparison between tensors returns a tensor, not bool
             if (is_tensor and torch.any(diff_obj_stash)) or (not is_tensor and diff_obj_stash):


### PR DESCRIPTION
When loading tensors from pickle, there's a comparison to trigger a warning if PickledDataLink was called twice with different stashes.

This comparison breaks when using tensors, because == comparison returns a tensor. 

For example, 

```
if torch.Tensor([False, False]): 
    pass
```

Will return `RuntimeError: bool value of Tensor with more than one value is ambiguous`.

Now, there's a distinction being made to check that all elements in a tensor are exactly the same. I wasn't able to fix this without making this explicit distinction, but please let me know if you know how!
