### PR TITLE
Additional special tokens

### DIFF
--- a/flambe/field/text.py
+++ b/flambe/field/text.py
@@ -256,9 +256,10 @@ class TextField(Field):
         self.unk_numericals: Set[int] = set()
 
         self.vocab: Dict = odict()
-        self.specials = []
-        self.register_specials(
-            pad_token, unk_token, sos_token, eos_token, *additional_tokens)
+        additional_tokens = [] if additional_tokens is None else additional_tokens
+        specials = [pad_token, unk_token, sos_token, eos_token, *additional_tokens]
+        self.specials = [special for special in specials
+                         if special is not None and special not in self.vocab]
 
         self.register_attrs('vocab')
 
@@ -525,7 +526,7 @@ class TextField(Field):
             Important: this flag will only work when using embeddings.
         additional_tokens: Optional[Union[List[str], Tuple[str]]]
             Additional tokens that should be included in the vocab,
-            and not be embedded as `unknown`
+            and not be embedded as `unknown`.
 
         Returns
         -------

--- a/tests/unit/field/test_text_field.py
+++ b/tests/unit/field/test_text_field.py
@@ -301,7 +301,7 @@ def test_load_embeddings_with_extra_tokens():
         embeddings="tests/data/dummy_embeddings/test.txt",
         pad_token=None,
         unk_init_all=False,
-        additional_tokens=['<a>', '<b>', '<c>']
+        additional_special_tokens=['<a>', '<b>', '<c>']
     )
     dummy = "a test ! <a> <b> "
     field.setup([dummy])
@@ -425,7 +425,7 @@ def test_setup_with_extra_tokens():
         embeddings="tests/data/dummy_embeddings/test.txt",
         pad_token=None,
         unk_init_all=False,
-        additional_tokens=['<a>', '<b>', '<c>']
+        additional_special_tokens=['<a>', '<b>', '<c>']
     )
 
     dummy = "this is a test"
@@ -505,7 +505,3 @@ def test_text_process_nested_dict_in_list_in_dict():
             'text2': [4, 3]}, {
             'text3': [[2, 3, 4], [4, 3, 5]]
         }]
-
-if __name__ == '__main__':
-    test_setup_with_extra_tokens()
-    test_load_embeddings_with_extra_tokens()


### PR DESCRIPTION
added the argument `additional_special_tokens` to the textfield's constructor and its from_embeddings method.

`additional_special_tokens`:
Additional tokens that have a reserved interpretation in the context of the current experiment, and that should therefore never be treated as "unknown". Passing them in here will make sure that they will have their own embedding that can be trained.