### PR TITLE
Hotfix to PR284

### DIFF
--- a/flambe/experiment/experiment.py
+++ b/flambe/experiment/experiment.py
@@ -276,7 +276,7 @@ class Experiment(ClusterRunnable):
         # By default use all CPUs if no GPU is present
         devices = self.devices if self.devices else None
         if devices is None:
-            devices = get_default_devices()
+            devices = get_default_devices(debug=debug)
 
         to_resume = None
         if isinstance(self.resume, str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,3 @@ awscli~=1.17
 transformers~=2.2.1
 jinja2~=2.10.1
 ninja~=1.9.0
-PyYAML==5.2


### PR DESCRIPTION
- hotfix to [PR 284](https://github.com/asappresearch/flambe/pull/284) (correctly forwarding debug in `get_default_devices` call
- removes PyYAML as a dependency as not called directly by Flambé and current version was flagged by the safety tool